### PR TITLE
docs+test: refine scope docs, add symptom examples & benchmarks

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -19,10 +19,12 @@ This document defines the architectural boundaries and design principles of the 
 This project does not aim to:
 
 - Replace Python's standard logging module
-- Provide distributed tracing or OpenTelemetry integration
+- Create, record, or export distributed traces / spans — this project never produces spans; span creation and export remain the job of OpenTelemetry or the Application Insights SDK
 - Manage log aggregation or external logging backends
 - Modify the root logger's handlers or formatters
 - Interfere with the Azure Functions worker's logging pipeline
+
+> **OpenTelemetry, scoped.** The blanket "no OpenTelemetry integration" non-goal from v0.1.0 has been narrowed. The library now ships an **opt-in** OpenTelemetry *log correlation* feature (`setup_logging(activate_trace_context=True)`, requires the `[otel]` extra): it binds the host's W3C trace context so existing OpenTelemetry log records inherit the invocation's `trace_id` / `span_id`. This is **correlation, not tracing** — the library still never creates, records, or exports spans (see the non-goal above).
 
 ## Design Principles
 

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,12 @@ test: ensure-hatch
 	@echo "Running tests..."
 	@$(HATCH) run test
 
+.PHONY: bench
+bench: ensure-hatch
+	@echo "Running micro-benchmarks..."
+	@$(HATCH) run python benchmarks/bench.py
+
+
 .PHONY: cov
 cov: ensure-hatch
 	@$(HATCH) run cov

--- a/PRD.md
+++ b/PRD.md
@@ -36,15 +36,15 @@ specifically designed to work safely within the Azure Functions worker architect
 
 ## 3. Non-Goals (v0.1.0)
 
-The initial version does not provide:
+The initial version (v0.1.0) did not provide the items below. Several have since shipped; this list is kept for historical scope context, with current status annotated. See also §11 "Future Enhancements".
 
-- Full JSON structured logging (planned for v0.2.0)
-- `host.json` log level conflict warning (planned for v0.2.0)
-- Sampling or log volume control
-- OpenTelemetry integration
-- Async context propagation across threads
-- Distributed tracing
-- Log aggregation or external backend integrations
+- ~~Full JSON structured logging~~ — **shipped in v0.2.0** (`JsonFormatter`)
+- ~~`host.json` log level conflict warning~~ — **shipped in v0.2.0**
+- ~~Sampling or log volume control~~ — **shipped** (`SamplingFilter`)
+- ~~OpenTelemetry integration~~ — **partially shipped:** opt-in OpenTelemetry *log correlation* via the `[otel]` extra (`activate_trace_context=True`). Span creation / trace export remains a non-goal (see below).
+- Async context propagation across threads (still a non-goal; contextvars do not follow `ThreadPoolExecutor` / background threads)
+- Distributed tracing — creating, recording, or exporting spans (**permanent non-goal**; use OpenTelemetry or the Application Insights SDK)
+- Log aggregation or external backend integrations (still a non-goal)
 
 ## 4. Target Users
 

--- a/README.md
+++ b/README.md
@@ -361,6 +361,97 @@ At startup the library warns when your `host.json` — or `AzureFunctionsJobHost
 - You want PII redaction or noise control for third-party loggers
 - Your `host.json` config silently suppresses logs and you don't know why
 
+## Common symptoms → fixes
+
+Arriving with a symptom rather than a feature name? Start here. Each entry lists the minimal setup, what the resulting log proves, and — just as importantly — what it *cannot* prove.
+
+<details>
+<summary><strong>My <code>INFO</code> logs are invisible in Azure</strong></summary>
+
+**Likely cause:** a `host.json` log level (or an `AzureFunctionsJobHost__logging__logLevel__...` app setting) is suppressing the level your app emits.
+
+```python
+setup_logging()  # warns at startup if host.json suppresses a level you emit
+```
+
+**What you'll see:** a startup warning naming the conflicting level. **Proves:** your configured level is dropping records. **Does not prove:** that the record ever reached Application Insights ingestion — that is a separate pipeline concern.
+
+→ [host.json conflict detection](#hostjson-conflict-detection)
+</details>
+
+<details>
+<summary><strong>Logs from different invocations are interleaved</strong></summary>
+
+```python
+with logging_context(context):
+    logger.info("Processing order")
+```
+
+Every record now carries `invocation_id`. Filter by it (see [Query in Application Insights](#query-in-application-insights)) to isolate a single execution. **Proves:** which records belong to the same invocation. **Does not prove:** ordering across workers — timestamps are per-process.
+
+→ [Invocation context](#invocation-context)
+</details>
+
+<details>
+<summary><strong>I want to know whether only the first request is slow</strong></summary>
+
+Every record carries `cold_start`. Query `cold_start == "true"` to find first-invocation records.
+
+> **Caveat:** `cold_start=True` means the first invocation observed by *this Python worker process* after module load — **not** a platform-level cold-start metric. It does not measure host allocation or worker startup time before the first instrumented invocation.
+
+→ [Invocation context](#invocation-context)
+</details>
+
+<details>
+<summary><strong>Which worker instance produced this error?</strong></summary>
+
+Every record carries `host_instance_id`, a best-effort identifier of the worker instance (resolved from `WEBSITE_INSTANCE_ID` → `WEBSITE_POD_NAME` → `CONTAINER_NAME` → `socket.gethostname()`). **Proves:** records sharing an instance id came from the same worker. **Does not prove:** equality with Application Insights' `cloud_RoleInstance` — it is complementary, not guaranteed identical.
+
+→ [Invocation context](#invocation-context)
+</details>
+
+<details>
+<summary><strong>Azure SDK / third-party loggers are too noisy</strong></summary>
+
+```python
+from azure_functions_logging import SamplingFilter
+
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").addFilter(SamplingFilter(rate=10))  # keep at most 10 records/sec
+```
+
+`SamplingFilter` rate-limits chatty loggers before they reach aggregation. **Proves nothing about correctness** — it deliberately drops records, so do not sample loggers you need complete.
+
+→ [Noise control & PII redaction](#noise-control--pii-redaction)
+</details>
+
+<details>
+<summary><strong>I'm worried sensitive values are being logged</strong></summary>
+
+```python
+from azure_functions_logging import RedactionFilter
+
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RedactionFilter())  # masks passwords, tokens, secrets, connection strings — recursive, case-insensitive
+```
+
+**Proves:** matched keys are masked before records leave the process. **Does not prove:** protection for secrets embedded inside free-text messages — redaction is key-based; pass `sensitive_keys=[...]` to extend coverage.
+
+→ [Noise control & PII redaction](#noise-control--pii-redaction)
+</details>
+
+<details>
+<summary><strong>I want worker logs correlated to the invocation trace</strong></summary>
+
+```python
+setup_logging(activate_trace_context=True)  # requires: pip install azure-functions-logging[otel]
+
+with logging_context(context):
+    logger.info("processing")  # OpenTelemetry record inherits the invocation trace_id / span_id
+```
+
+**Proves:** your existing OpenTelemetry log records inherit the host invocation's `trace_id` / `span_id`. **Does not prove:** a span was created or exported — this is correlation, not tracing (see [OpenTelemetry trace correlation](#opentelemetry-trace-correlation)).
+</details>
+
 ## Documentation
 
 - Full docs: [yeongseon.dev/azure-functions-python/logging](https://yeongseon.dev/azure-functions-python/logging/)

--- a/README.md
+++ b/README.md
@@ -414,8 +414,9 @@ Every record carries `host_instance_id`, a best-effort identifier of the worker 
 <summary><strong>Azure SDK / third-party loggers are too noisy</strong></summary>
 
 ```python
-from azure_functions_logging import SamplingFilter
 import logging
+
+from azure_functions_logging import SamplingFilter
 
 logging.getLogger("azure.core.pipeline.policies.http_logging_policy").addFilter(SamplingFilter(rate=10))  # keep at most 10 records/sec
 ```
@@ -429,8 +430,9 @@ logging.getLogger("azure.core.pipeline.policies.http_logging_policy").addFilter(
 <summary><strong>I'm worried sensitive values are being logged</strong></summary>
 
 ```python
-from azure_functions_logging import RedactionFilter
 import logging
+
+from azure_functions_logging import RedactionFilter
 
 for handler in logging.getLogger().handlers:
     handler.addFilter(RedactionFilter())  # masks passwords, tokens, secrets, connection strings — recursive, case-insensitive

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Every record now carries `invocation_id`. Filter by it (see [Query in Applicatio
 <details>
 <summary><strong>I want to know whether only the first request is slow</strong></summary>
 
-Every record carries `cold_start`. Query `cold_start == "true"` to find first-invocation records.
+Every record carries `cold_start`. To find first-invocation records, query it using the shape that matches your ingestion pipeline — `tostring(payload.cold_start) == "true"` when the JSON stays in `message`, or `customDimensions.cold_start == "true"` when fields are promoted (see [Query in Application Insights](#query-in-application-insights)).
 
 > **Caveat:** `cold_start=True` means the first invocation observed by *this Python worker process* after module load — **not** a platform-level cold-start metric. It does not measure host allocation or worker startup time before the first instrumented invocation.
 
@@ -415,6 +415,7 @@ Every record carries `host_instance_id`, a best-effort identifier of the worker 
 
 ```python
 from azure_functions_logging import SamplingFilter
+import logging
 
 logging.getLogger("azure.core.pipeline.policies.http_logging_policy").addFilter(SamplingFilter(rate=10))  # keep at most 10 records/sec
 ```
@@ -429,6 +430,7 @@ logging.getLogger("azure.core.pipeline.policies.http_logging_policy").addFilter(
 
 ```python
 from azure_functions_logging import RedactionFilter
+import logging
 
 for handler in logging.getLogger().handlers:
     handler.addFilter(RedactionFilter())  # masks passwords, tokens, secrets, connection strings — recursive, case-insensitive

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,64 @@
+# Benchmarks
+
+Minimal, reproducible micro-benchmarks for the hot paths `azure-functions-logging`
+adds to your logging pipeline.
+
+## Running
+
+```bash
+make bench                 # human-readable table (via hatch)
+python benchmarks/bench.py # or run directly in any env with the package installed
+python benchmarks/bench.py --json          # machine-readable output
+python benchmarks/bench.py --include-import # also run the import-reload proxy
+```
+
+No pytest, no third-party benchmark framework, no network, no Azure — the script
+uses only the stdlib plus this package's public API.
+
+## What these numbers are (and are not)
+
+These are **in-process CPU micro-benchmarks**. Each row is the median (across
+repeats) of the per-operation cost on the machine that ran it, with GC disabled
+during timing and a warmup pass.
+
+They measure the cost this library adds **inside the Python worker process**:
+context injection, JSON formatting, and the filters. They deliberately say
+**nothing** about:
+
+- gRPC transport from the worker to the host
+- Application Insights ingestion, sampling, or schema mapping
+- End-to-end latency of an HTTP invocation
+
+Treat them as "is the per-record overhead in the microseconds or milliseconds
+range?" evidence — not as a platform performance model. Re-run on your own
+hardware for numbers that reflect your environment.
+
+## Reference run
+
+Captured on the maintainer's dev machine. **Your numbers will differ** — this
+table exists to show order-of-magnitude, not to be a fixed contract.
+
+| Benchmark | Median | Notes |
+| --- | ---: | --- |
+| `setup_logging(logger_name='bench')` | ~1.2 µs | One-time per process (idempotent), not per-request |
+| `inject_context` + `restore_context` | ~6.7 µs | Lower-level path; per invocation |
+| `logging_context(context)` enter/exit | ~8.3 µs | Recommended primary path; per invocation |
+| `JsonFormatter.format(record)` | ~15 µs | Per emitted record, only when a record is actually formatted |
+| `SamplingFilter.filter(record)` | ~0.8 µs | Per record on a filtered logger |
+| `RedactionFilter.filter(record)` | ~11 µs | Per record (includes record construction); recursive over a nested payload |
+
+_Environment: CPython 3.10.12, Linux x86_64._
+
+### Reading the table
+
+- **Per-invocation context cost** (`logging_context`) is a single-digit
+  microsecond price paid once per request — negligible next to any I/O the
+  handler does.
+- **`JsonFormatter` / `RedactionFilter`** costs are paid **per emitted record**,
+  and only for records that actually reach a handler using them. Chatty debug
+  logging amplifies these; `SamplingFilter` (sub-microsecond) is the lever to
+  pull when volume is the concern.
+- **`setup_logging`** is a one-time startup cost, not a per-request cost.
+
+To refresh this table, run `python benchmarks/bench.py` and update the numbers
+(and the environment line) to match your run.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -40,7 +40,7 @@ table exists to show order-of-magnitude, not to be a fixed contract.
 
 | Benchmark | Median | Notes |
 | --- | ---: | --- |
-| `setup_logging(logger_name='bench')` | ~1.2 µs | One-time per process (idempotent), not per-request |
+| `setup_logging(logger_name='bench')` **[first-time]** | ~10 µs | First-time configuration of one named logger (idempotency guard reset each iteration so this is *not* the re-entry fast-path). Paid once per process, not per-request. |
 | `inject_context` + `restore_context` | ~6.7 µs | Lower-level path; per invocation |
 | `logging_context(context)` enter/exit | ~8.3 µs | Recommended primary path; per invocation |
 | `JsonFormatter.format(record)` | ~15 µs | Per emitted record, only when a record is actually formatted |

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -81,21 +81,47 @@ class Result:
         return f"{self.name:<38} {self.median_ns_per_op:>12,.0f} ns {self.min_ns_per_op:>12,.0f} ns"
 
 
-def _time_once(fn: Callable[[], None], iterations: int) -> float:
-    """Return ns/op for a single batch of ``iterations`` calls."""
-    start = time.perf_counter_ns()
+def _time_once(
+    fn: Callable[[], None],
+    iterations: int,
+    before: Callable[[], None] | None = None,
+) -> float:
+    """Return ns/op for a batch of ``iterations`` calls.
+
+    When ``before`` is provided it runs untimed before each call — used to reset
+    state (e.g. so ``setup_logging`` measures first-time cost, not its idempotent
+    fast-path) without charging the reset to the measurement.
+    """
+    if before is None:
+        start = time.perf_counter_ns()
+        for _ in range(iterations):
+            fn()
+        return (time.perf_counter_ns() - start) / iterations
+
+    total = 0
     for _ in range(iterations):
+        before()
+        start = time.perf_counter_ns()
         fn()
-    elapsed = time.perf_counter_ns() - start
-    return elapsed / iterations
+        total += time.perf_counter_ns() - start
+    return total / iterations
 
 
-def bench(name: str, fn: Callable[[], None], *, iterations: int, repeats: int = 7) -> Result:
-    fn()  # warmup / JIT-nothing but populate caches
+def bench(
+    name: str,
+    fn: Callable[[], None],
+    *,
+    iterations: int,
+    repeats: int = 7,
+    before: Callable[[], None] | None = None,
+) -> Result:
+    if before is not None:
+        before()
+    fn()  # warmup / populate caches
     gc_was_enabled = gc.isenabled()
     gc.disable()
     try:
-        samples = [_time_once(fn, iterations) for _ in range(repeats)]
+        samples = [_time_once(fn, iterations, before) for _ in range(repeats)]
     finally:
         if gc_was_enabled:
             gc.enable()
@@ -143,11 +169,30 @@ def run_benchmarks() -> list[Result]:
 
     results: list[Result] = []
 
-    # setup_logging() — configure a dedicated named logger to avoid touching root.
+    # setup_logging() first-time configuration cost. Without resetting state, the
+    # idempotency guard (_configured_loggers) would short-circuit every call after
+    # warmup and we'd measure re-entry, not real configuration. The reset runs
+    # untimed via ``before`` so only setup_logging() itself is measured.
+    import azure_functions_logging._setup as _setup_mod
+
+    def _reset_setup_state() -> None:
+        _setup_mod._configured_loggers.discard("bench")
+        lgr = logging.getLogger("bench")
+        lgr.handlers.clear()
+        lgr.filters.clear()
+
     def _setup() -> None:
         setup_logging(logger_name="bench")
 
-    results.append(bench("setup_logging(logger_name='bench')", _setup, iterations=2_000, repeats=5))
+    results.append(
+        bench(
+            "setup_logging(logger_name='bench') [first-time]",
+            _setup,
+            iterations=2_000,
+            repeats=5,
+            before=_reset_setup_state,
+        )
+    )
 
     ctx = _FakeContext()
 

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Minimal, reproducible micro-benchmarks for azure-functions-logging.
+
+Run with:
+
+    python benchmarks/bench.py            # human-readable table
+    python benchmarks/bench.py --json     # machine-readable JSON
+
+Design goals (see issue #375):
+
+- **Standalone.** Uses only the stdlib plus the package's own public API. No
+  pytest, no third-party benchmark framework, no network, no Azure.
+- **Reproducible.** Deterministic fake context, fixed iteration counts, warmup
+  pass, and median-of-repeats reporting to damp scheduler noise.
+- **Honest.** These are *in-process micro-benchmarks* of the hot paths this
+  library adds. They measure CPU cost per operation on the machine running
+  them; they say nothing about gRPC, host ingestion, or Application Insights.
+
+The numbers are intentionally small in scope: import cost, setup cost, and the
+per-record cost of context injection, JSON formatting, and the filters.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import gc
+import json
+import logging
+import platform
+import statistics
+import sys
+import time
+from typing import Callable
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+class _FakeTraceContext:
+    trace_parent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    trace_state = ""
+
+
+class _FakeContext:
+    """Duck-typed stand-in for azure.functions.Context (no azure dep needed)."""
+
+    invocation_id = "706b8e5c-a630-4309-b815-6410526f237a"
+    function_name = "bench_handler"
+    trace_context = _FakeTraceContext()
+
+
+def _make_record() -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="bench",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Processing order %s",
+        args=("o-42",),
+        exc_info=None,
+    )
+    # A representative payload of structured extras.
+    record.order_id = "o-42"  # type: ignore[attr-defined]
+    record.user = {"id": "u-1", "password": "hunter2", "email": "a@b.com"}  # type: ignore[attr-defined]
+    return record
+
+
+# --------------------------------------------------------------------------- #
+# Timing harness
+# --------------------------------------------------------------------------- #
+@dataclass
+class Result:
+    name: str
+    iterations: int
+    repeats: int
+    median_ns_per_op: float
+    min_ns_per_op: float
+
+    def as_row(self) -> str:
+        return f"{self.name:<38} {self.median_ns_per_op:>12,.0f} ns {self.min_ns_per_op:>12,.0f} ns"
+
+
+def _time_once(fn: Callable[[], None], iterations: int) -> float:
+    """Return ns/op for a single batch of ``iterations`` calls."""
+    start = time.perf_counter_ns()
+    for _ in range(iterations):
+        fn()
+    elapsed = time.perf_counter_ns() - start
+    return elapsed / iterations
+
+
+def bench(name: str, fn: Callable[[], None], *, iterations: int, repeats: int = 7) -> Result:
+    fn()  # warmup / JIT-nothing but populate caches
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        samples = [_time_once(fn, iterations) for _ in range(repeats)]
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+    return Result(
+        name=name,
+        iterations=iterations,
+        repeats=repeats,
+        median_ns_per_op=statistics.median(samples),
+        min_ns_per_op=min(samples),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Benchmarks
+# --------------------------------------------------------------------------- #
+def bench_import() -> Result:
+    """One-shot: cost of importing the package cold (subprocess-free estimate).
+
+    We can't truly re-import into a clean interpreter here without a subprocess,
+    so we measure ``importlib.reload`` of the top module as a proxy. Reported
+    separately and labeled as a proxy.
+    """
+    import importlib
+
+    import azure_functions_logging as pkg
+
+    def _reload() -> None:
+        importlib.reload(pkg)
+
+    return bench(
+        "import azure_functions_logging (reload proxy)", _reload, iterations=200, repeats=5
+    )
+
+
+def run_benchmarks() -> list[Result]:
+    from azure_functions_logging import (
+        JsonFormatter,
+        RedactionFilter,
+        SamplingFilter,
+        inject_context,
+        logging_context,
+        restore_context,
+        setup_logging,
+    )
+
+    results: list[Result] = []
+
+    # setup_logging() — configure a dedicated named logger to avoid touching root.
+    def _setup() -> None:
+        setup_logging(logger_name="bench")
+
+    results.append(bench("setup_logging(logger_name='bench')", _setup, iterations=2_000, repeats=5))
+
+    ctx = _FakeContext()
+
+    # inject_context() + restore_context() round trip (per warm invocation).
+    def _inject_restore() -> None:
+        tokens = inject_context(ctx)
+        restore_context(tokens)
+
+    results.append(bench("inject_context + restore_context", _inject_restore, iterations=50_000))
+
+    # logging_context() context manager (recommended primary path).
+    def _logging_context() -> None:
+        with logging_context(ctx):
+            pass
+
+    results.append(
+        bench("logging_context(context) enter/exit", _logging_context, iterations=50_000)
+    )
+
+    # JsonFormatter.format() per record.
+    json_formatter = JsonFormatter()
+    json_record = _make_record()
+
+    def _json_format() -> None:
+        json_formatter.format(json_record)
+
+    results.append(bench("JsonFormatter.format(record)", _json_format, iterations=50_000))
+
+    # SamplingFilter.filter() per record (high rate so nothing is dropped).
+    sampling = SamplingFilter(rate=1_000_000, window=1.0)
+    sample_record = _make_record()
+
+    def _sampling() -> None:
+        sampling.filter(sample_record)
+
+    results.append(bench("SamplingFilter.filter(record)", _sampling, iterations=100_000))
+
+    # RedactionFilter.filter() per record (with a nested sensitive payload).
+    redaction = RedactionFilter()
+
+    def _redaction() -> None:
+        redaction.filter(_make_record())
+
+    results.append(
+        bench("RedactionFilter.filter(record) [new record]", _redaction, iterations=50_000)
+    )
+
+    return results
+
+
+def _environment() -> dict[str, str]:
+    return {
+        "python": sys.version.split()[0],
+        "implementation": platform.python_implementation(),
+        "platform": platform.platform(),
+        "processor": platform.processor() or "unknown",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument(
+        "--include-import",
+        action="store_true",
+        help="also run the import-reload proxy benchmark (noisy)",
+    )
+    args = parser.parse_args()
+
+    # Silence actual log output during benchmarking.
+    logging.getLogger("bench").handlers.clear()
+    logging.getLogger("bench").addHandler(logging.NullHandler())
+
+    results = run_benchmarks()
+    if args.include_import:
+        results.append(bench_import())
+
+    env = _environment()
+
+    if args.json:
+        print(json.dumps({"environment": env, "results": [asdict(r) for r in results]}, indent=2))
+        return 0
+
+    print("azure-functions-logging — micro-benchmarks")
+    print(
+        f"  {env['implementation']} {env['python']} on {env['platform']}\n"
+        f"  (in-process CPU cost per op; excludes gRPC / host / ingestion)\n"
+    )
+    print(f"{'benchmark':<38} {'median':>15} {'min':>15}")
+    print("-" * 70)
+    for r in results:
+        print(r.as_row())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Follow-up to an external review of the library. Rather than adding new features, this PR **sharpens scope accuracy, docs usability, and performance evidence** for existing behavior. Three focused, low-risk changes (docs + a standalone benchmark script — no `src/` or `tests/` changes).

Closes #373, closes #374, closes #375.

## Changes

### `docs: reconcile PRD/DESIGN non-goals with shipped features` (#373)
- `DESIGN.md` / `PRD.md` non-goals were stale vs. the README. Notably DESIGN flatly said "no OpenTelemetry integration" while the library ships opt-in OTel **log correlation** (`[otel]` extra).
- Now distinguishes the permanent non-goal (**never create/record/export spans**) from the shipped opt-in **correlation** feature; JSON/sampling/redaction marked as shipped.

### `docs: add symptom-driven usage examples` (#374)
- New README "Common symptoms → fixes" section: 7 real symptoms (invisible INFO logs, interleaved logs, first-request-slow, which worker, noisy SDK logs, PII worry, worker↔trace correlation).
- Each entry: minimal setup → what it proves → **what it cannot prove**, keeping the `cold_start` per-worker-process caveat.
- Fixed an inaccurate snippet: `SamplingFilter(rate=0.1)` → `rate=10` (`rate` is an int, events-per-window).

### `test: add minimal reproducible performance benchmarks` (#375)
- `benchmarks/bench.py` — standalone, stdlib-only, `--json` supported. Measures import (proxy), `setup_logging`, context injection, JSON formatting, and filters.
- `benchmarks/README.md` documents scope (in-process CPU only; excludes gRPC/host/ingestion) + a reference run.
- `make bench` target added.

## Reference benchmark numbers (CPython 3.10.12, Linux x86_64)
| Op | Median |
| --- | ---: |
| `logging_context` enter/exit | ~8.3 µs / invocation |
| `JsonFormatter.format` | ~15 µs / record |
| `SamplingFilter.filter` | ~0.8 µs / record |
| `setup_logging` | ~1.2 µs (one-time) |

## Validation
- `make lint` — pass
- `make bench` — runs, exit 0
- `benchmarks/bench.py` — ruff clean
- No `src/` or `tests/` changes → existing suite / coverage unaffected

## Notes
Translated READMEs (ko/ja/zh) intentionally not updated in this PR (best-effort per AGENTS.md; English is canonical).