### PR TITLE
docs: sync symptom-driven examples into translated READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -337,6 +337,101 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 - サードパーティロガーに対して PII redaction やノイズ制御が必要なとき
 - `host.json` 設定が静かにログを抑制し、その理由がわからないとき
 
+## 症状 → 解決
+
+機能名ではなく症状から探していますか？ここから始めてください。各項目は、最小限のセットアップ、結果のログが**証明すること**、そして同じく重要な**証明できないこと**を示します。
+
+<details>
+<summary><strong><code>INFO</code> ログが Azure で見えない</strong></summary>
+
+**考えられる原因:** `host.json` のログレベル（または `AzureFunctionsJobHost__logging__logLevel__...` アプリ設定）が、アプリが出力するレベルを抑制している。
+
+```python
+setup_logging()  # host.json が出力レベルを抑制している場合、起動時に警告
+```
+
+**見えるもの:** 衝突レベルを名指しする起動警告。**証明:** 設定レベルがレコードをドロップしていること。**証明できないこと:** そのレコードが実際に Application Insights の ingestion に到達したか — これは別のパイプラインの問題です。
+
+→ [host.json 衝突検出](#hostjson-衝突検出)
+</details>
+
+<details>
+<summary><strong>異なる呼び出しのログが入り交じる</strong></summary>
+
+```python
+with logging_context(context):
+    logger.info("Processing order")
+```
+
+これですべてのレコードに `invocation_id` が付与されます。それでフィルタリングすれば（[Application Insights でのクエリ](#application-insights-でのクエリ) 参照）単一の実行を分離できます。**証明:** どのレコードが同じ呼び出しに属するか。**証明できないこと:** worker 間の順序 — タイムスタンプはプロセスごとです。
+
+→ [呼び出しコンテキスト](#呼び出しコンテキスト)
+</details>
+
+<details>
+<summary><strong>最初のリクエストだけが遅いのか知りたい</strong></summary>
+
+すべてのレコードに `cold_start` が付与されます。初回呼び出しのレコードを探すには、ingestion パイプラインに合った形でクエリします — JSON が `message` に残る場合は `tostring(payload.cold_start) == "true"`、フィールドが昇格される場合は `customDimensions.cold_start == "true"`（[Application Insights でのクエリ](#application-insights-でのクエリ) 参照）。
+
+> **注意:** `cold_start=True` は、モジュールロード後に *この Python worker プロセス* が最初に観測した呼び出しを意味します — プラットフォームレベルの cold-start メトリクスでは**ありません**。初回の計測対象呼び出しより前の host 割り当てや worker 起動時間は測定しません。
+
+→ [呼び出しコンテキスト](#呼び出しコンテキスト)
+</details>
+
+<details>
+<summary><strong>このエラーを出した worker インスタンスはどれか？</strong></summary>
+
+すべてのレコードに `host_instance_id` が付与されます。これはログを生成した worker インスタンスの best-effort な識別子です（`WEBSITE_INSTANCE_ID` → `WEBSITE_POD_NAME` → `CONTAINER_NAME` → `socket.gethostname()` の順で解決）。**証明:** 同じ instance id を持つレコードは同じ worker から出たこと。**証明できないこと:** Application Insights の `cloud_RoleInstance` との一致 — 補完的であり、同一とは保証されません。
+
+→ [呼び出しコンテキスト](#呼び出しコンテキスト)
+</details>
+
+<details>
+<summary><strong>Azure SDK / サードパーティロガーが騒がしすぎる</strong></summary>
+
+```python
+import logging
+
+from azure_functions_logging import SamplingFilter
+
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").addFilter(SamplingFilter(rate=10))  # 毎秒最大 10 レコードを保持
+```
+
+`SamplingFilter` は騒がしいロガーが集計に到達する前にレートを制限します。**正確性については何も証明しません** — 意図的にレコードを破棄するため、完全に必要なロガーはサンプリングしないでください。
+
+→ [ノイズ制御と PII Redaction](#ノイズ制御と-pii-redaction)
+</details>
+
+<details>
+<summary><strong>機密な値がログに出ていないか心配</strong></summary>
+
+```python
+import logging
+
+from azure_functions_logging import RedactionFilter
+
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RedactionFilter())  # パスワード、トークン、シークレット、接続文字列をマスク — 再帰的、大文字小文字を区別しない
+```
+
+**証明:** 一致したキーがレコードがプロセスを離れる前にマスクされること。**証明できないこと:** フリーテキストメッセージ内に埋め込まれたシークレットの保護 — redaction はキーベースです。`sensitive_keys=[...]` を渡して範囲を拡張してください。
+
+→ [ノイズ制御と PII Redaction](#ノイズ制御と-pii-redaction)
+</details>
+
+<details>
+<summary><strong>worker ログを呼び出しトレースに相関付けたい</strong></summary>
+
+```python
+setup_logging(activate_trace_context=True)  # 必要: pip install azure-functions-logging[otel]
+
+with logging_context(context):
+    logger.info("processing")  # OpenTelemetry レコードが呼び出しの trace_id / span_id を継承
+```
+
+**証明:** 既存の OpenTelemetry ログレコードが host 呼び出しの `trace_id` / `span_id` を継承すること。**証明できないこと:** span が作成またはエクスポートされたこと — これは tracing ではなく correlation です（[OpenTelemetry トレース相関付け](#opentelemetry-トレース相関付け) 参照）。
+</details>
+
 ## ドキュメント
 
 - 完全なドキュメント: [yeongseon.dev/azure-functions-python/logging](https://yeongseon.dev/azure-functions-python/logging/)

--- a/README.ko.md
+++ b/README.ko.md
@@ -337,6 +337,101 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 - 서드파티 로거에 대해 PII redaction이나 노이즈 제어를 원할 때
 - `host.json` 구성이 조용히 로그를 억제하는데 이유를 모를 때
 
+## 증상 → 해결
+
+기능 이름이 아니라 증상을 들고 오셨나요? 여기서 시작하세요. 각 항목은 최소 설정, 결과 로그가 **증명하는 것**, 그리고 그만큼 중요한 **증명하지 못하는 것**을 함께 정리합니다.
+
+<details>
+<summary><strong><code>INFO</code> 로그가 Azure에서 보이지 않아요</strong></summary>
+
+**유력한 원인:** `host.json` 로그 레벨(또는 `AzureFunctionsJobHost__logging__logLevel__...` 앱 설정)이 앱이 내보내는 레벨을 억제하고 있음.
+
+```python
+setup_logging()  # host.json이 내보내는 레벨을 억제하면 시작 시점에 경고
+```
+
+**보게 되는 것:** 충돌 레벨을 명시하는 시작 경고. **증명:** 설정된 레벨이 레코드를 누락시키고 있음. **증명 못 함:** 그 레코드가 실제로 Application Insights ingestion에 도달했는지 — 이는 별개의 파이프라인 문제입니다.
+
+→ [host.json 충돌 감지](#hostjson-충돌-감지)
+</details>
+
+<details>
+<summary><strong>서로 다른 호출의 로그가 뒤섞여요</strong></summary>
+
+```python
+with logging_context(context):
+    logger.info("Processing order")
+```
+
+이제 모든 레코드에 `invocation_id`가 담깁니다. 그것으로 필터링하면([Application Insights에서 쿼리](#application-insights에서-쿼리) 참조) 단일 실행을 격리할 수 있습니다. **증명:** 어떤 레코드가 같은 호출에 속하는지. **증명 못 함:** worker 간 순서 — 타임스탬프는 프로세스별입니다.
+
+→ [호출 컨텍스트](#호출-컨텍스트)
+</details>
+
+<details>
+<summary><strong>첫 요청만 느린지 알고 싶어요</strong></summary>
+
+모든 레코드에 `cold_start`가 담깁니다. 첫 호출 레코드를 찾으려면 ingestion 파이프라인에 맞는 형태로 쿼리하세요 — JSON이 `message`에 남으면 `tostring(payload.cold_start) == "true"`, 필드가 승격되면 `customDimensions.cold_start == "true"`([Application Insights에서 쿼리](#application-insights에서-쿼리) 참조).
+
+> **주의:** `cold_start=True`는 모듈 로드 후 *이 Python worker 프로세스*가 처음 관측한 호출을 의미합니다 — 플랫폼 수준의 cold-start 지표가 **아닙니다**. 첫 계측 호출 이전의 host 할당이나 worker 시작 시간을 측정하지 않습니다.
+
+→ [호출 컨텍스트](#호출-컨텍스트)
+</details>
+
+<details>
+<summary><strong>이 오류를 낸 worker 인스턴스가 어느 것인가요?</strong></summary>
+
+모든 레코드에 `host_instance_id`가 담깁니다. 이는 로그를 생성한 worker 인스턴스의 best-effort 식별자입니다(`WEBSITE_INSTANCE_ID` → `WEBSITE_POD_NAME` → `CONTAINER_NAME` → `socket.gethostname()` 순으로 해석). **증명:** 같은 instance id를 가진 레코드는 같은 worker에서 나왔음. **증명 못 함:** Application Insights의 `cloud_RoleInstance`와의 동일성 — 보완적일 뿐 동일하다고 보장되지 않습니다.
+
+→ [호출 컨텍스트](#호출-컨텍스트)
+</details>
+
+<details>
+<summary><strong>Azure SDK / 서드파티 로거가 너무 시끄러워요</strong></summary>
+
+```python
+import logging
+
+from azure_functions_logging import SamplingFilter
+
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").addFilter(SamplingFilter(rate=10))  # 초당 최대 10개 레코드 유지
+```
+
+`SamplingFilter`는 시끄러운 로거가 집계에 도달하기 전에 비율을 제한합니다. **정확성에 대해서는 아무것도 증명하지 않습니다** — 의도적으로 레코드를 버리므로, 완전성이 필요한 로거는 샘플링하지 마세요.
+
+→ [노이즈 제어 및 PII Redaction](#노이즈-제어-및-pii-redaction)
+</details>
+
+<details>
+<summary><strong>민감한 값이 로깅되고 있을까 봐 걱정돼요</strong></summary>
+
+```python
+import logging
+
+from azure_functions_logging import RedactionFilter
+
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RedactionFilter())  # 비밀번호, 토큰, 시크릿, 연결 문자열 마스킹 — 재귀적, 대소문자 무시
+```
+
+**증명:** 일치하는 키가 레코드가 프로세스를 떠나기 전에 마스킹됨. **증명 못 함:** 자유 텍스트 메시지 안에 박힌 시크릿의 보호 — redaction은 키 기반입니다. `sensitive_keys=[...]`를 전달해 범위를 확장하세요.
+
+→ [노이즈 제어 및 PII Redaction](#노이즈-제어-및-pii-redaction)
+</details>
+
+<details>
+<summary><strong>worker 로그를 호출 트레이스와 상관시키고 싶어요</strong></summary>
+
+```python
+setup_logging(activate_trace_context=True)  # 필요: pip install azure-functions-logging[otel]
+
+with logging_context(context):
+    logger.info("processing")  # OpenTelemetry 레코드가 호출의 trace_id / span_id를 상속
+```
+
+**증명:** 기존 OpenTelemetry 로그 레코드가 host 호출의 `trace_id` / `span_id`를 상속함. **증명 못 함:** span이 생성되거나 내보내진 것 — 이는 tracing이 아니라 correlation입니다([OpenTelemetry 트레이스 상관관계](#opentelemetry-트레이스-상관관계) 참조).
+</details>
+
 ## 문서
 
 - 전체 문서: [yeongseon.dev/azure-functions-python/logging](https://yeongseon.dev/azure-functions-python/logging/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -336,6 +336,101 @@ curl -s "https://<your-app>.azurewebsites.net/api/logme?correlation_id=demo-123"
 - 您希望对第三方 logger 进行 PII redaction 或噪声控制时
 - 您的 `host.json` 配置静默抑制日志而您不知道原因时
 
+## 症状 → 修复
+
+带着症状而非功能名称前来？从这里开始。每个条目列出最小设置、结果日志**能证明什么**，以及同样重要的**不能证明什么**。
+
+<details>
+<summary><strong>我的 <code>INFO</code> 日志在 Azure 中不可见</strong></summary>
+
+**可能原因：** 某个 `host.json` 日志级别（或 `AzureFunctionsJobHost__logging__logLevel__...` 应用设置）正在抑制应用输出的级别。
+
+```python
+setup_logging()  # 若 host.json 抑制了你输出的级别，启动时会警告
+```
+
+**你会看到：** 一条命名冲突级别的启动警告。**证明：** 你配置的级别正在丢弃记录。**不能证明：** 该记录是否真的到达了 Application Insights ingestion — 那是另一个独立的管道问题。
+
+→ [host.json 冲突检测](#hostjson-冲突检测)
+</details>
+
+<details>
+<summary><strong>不同调用的日志交织在一起</strong></summary>
+
+```python
+with logging_context(context):
+    logger.info("Processing order")
+```
+
+现在每条记录都带有 `invocation_id`。按它过滤（参见[在 Application Insights 中查询](#在-application-insights-中查询)）即可隔离单次执行。**证明：** 哪些记录属于同一次调用。**不能证明：** worker 之间的顺序 — 时间戳是按进程的。
+
+→ [调用上下文](#调用上下文)
+</details>
+
+<details>
+<summary><strong>我想知道是不是只有第一次请求慢</strong></summary>
+
+每条记录都带有 `cold_start`。要查找首次调用的记录，请按与你的 ingestion 管道匹配的形式查询 — 当 JSON 保留在 `message` 中时用 `tostring(payload.cold_start) == "true"`，当字段被提升时用 `customDimensions.cold_start == "true"`（参见[在 Application Insights 中查询](#在-application-insights-中查询)）。
+
+> **注意：** `cold_start=True` 指模块加载后 *此 Python worker 进程* 观察到的首次调用 — **而非**平台级的 cold-start 指标。它不衡量首次受控调用之前的 host 分配或 worker 启动时间。
+
+→ [调用上下文](#调用上下文)
+</details>
+
+<details>
+<summary><strong>哪个 worker 实例产生了这个错误？</strong></summary>
+
+每条记录都带有 `host_instance_id`，这是产生日志的 worker 实例的 best-effort 标识符（按 `WEBSITE_INSTANCE_ID` → `WEBSITE_POD_NAME` → `CONTAINER_NAME` → `socket.gethostname()` 解析）。**证明：** 具有相同 instance id 的记录来自同一 worker。**不能证明：** 与 Application Insights 的 `cloud_RoleInstance` 相等 — 它是互补的，不保证完全一致。
+
+→ [调用上下文](#调用上下文)
+</details>
+
+<details>
+<summary><strong>Azure SDK / 第三方日志器太嗧</strong></summary>
+
+```python
+import logging
+
+from azure_functions_logging import SamplingFilter
+
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").addFilter(SamplingFilter(rate=10))  # 每秒最多保留 10 条记录
+```
+
+`SamplingFilter` 在嗧闹日志器到达聚合之前限制其速率。**它不证明任何正确性** — 它故意丢弃记录，因此不要对你需要完整的日志器采样。
+
+→ [噪声控制与 PII 脱敏](#噪声控制与-pii-脱敏)
+</details>
+
+<details>
+<summary><strong>我担心敏感值被记录下来</strong></summary>
+
+```python
+import logging
+
+from azure_functions_logging import RedactionFilter
+
+for handler in logging.getLogger().handlers:
+    handler.addFilter(RedactionFilter())  # 掩蔽密码、令牌、密钥、连接字符串 — 递归、不区分大小写
+```
+
+**证明：** 匹配的键在记录离开进程前被掩蔽。**不能证明：** 对嵌入自由文本消息中的密钥的保护 — 脱敏是基于键的；传入 `sensitive_keys=[...]` 以扩展覆盖范围。
+
+→ [噪声控制与 PII 脱敏](#噪声控制与-pii-脱敏)
+</details>
+
+<details>
+<summary><strong>我想将 worker 日志与调用追踪关联</strong></summary>
+
+```python
+setup_logging(activate_trace_context=True)  # 需要：pip install azure-functions-logging[otel]
+
+with logging_context(context):
+    logger.info("processing")  # OpenTelemetry 记录继承调用的 trace_id / span_id
+```
+
+**证明：** 你现有的 OpenTelemetry 日志记录继承 host 调用的 `trace_id` / `span_id`。**不能证明：** 创建或导出了 span — 这是关联（correlation）而非追踪（tracing）（参见[OpenTelemetry 追踪关联](#opentelemetry-追踪关联)）。
+</details>
+
 ## 文档
 
 - 完整文档: [yeongseon.dev/azure-functions-python/logging](https://yeongseon.dev/azure-functions-python/logging/)


### PR DESCRIPTION
## Summary
- Ports the **Common symptoms → fixes** section (added to the canonical `README.md` in #374) into all three translated READMEs: `README.ko.md`, `README.ja.md`, `README.zh-CN.md`.
- Each of the 7 symptom entries (invisible INFO logs, interleaved invocations, cold-start detection, worker instance id, noisy loggers, PII redaction, trace correlation) is fully translated, keeping code blocks identical to the English source (`import logging`, `rate=10`, etc.).
- In-page anchor links (`host.json conflict`, `invocation context`, `Query in App Insights`, `noise/PII`, `OpenTelemetry correlation`) are remapped to each language's translated section slugs — verified all 5 target headers resolve in every file.

## Notes
- Per `AGENTS.md`, translations are best-effort/community-maintained and never block; this is opportunistic sync after the English change already merged.
- Docs-only, no runtime or test impact.