### PR TITLE
feat: detect ineffective @with_context at decoration time

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ Every capability below has a full how-to on the [documentation site](https://yeo
 
 > **Worker instance.** Every record also carries `host_instance_id`, a best-effort identifier of the worker instance that produced the log (resolved from `WEBSITE_INSTANCE_ID` → `WEBSITE_POD_NAME` → `CONTAINER_NAME` → `socket.gethostname()`). It is complementary to, but not guaranteed equal to, Application Insights' `cloud_RoleInstance`.
 
+> **`@with_context` requires a declared context parameter.** The Azure Functions worker only supplies `func.Context` when your handler signature declares it, so `@with_context` must decorate a handler that accepts a `context: func.Context` parameter (or a `**kwargs`). If it can't receive the context, injection would be a silent no-op — the decorator now emits a `RuntimeWarning` at import time to flag this. Use `@with_context(strict=True)` to raise instead (CI-enforceable), or `@with_context(param="...")` to match a differently-named parameter.
+
 → [Usage: context injection](https://yeongseon.dev/azure-functions-python/logging/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.dev/azure-functions-python/logging/api/#with_context)
 
 ### Structured JSON output

--- a/src/azure_functions_logging/_decorator.py
+++ b/src/azure_functions_logging/_decorator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from typing import Any, Callable, TypeVar, overload
+import warnings
 
 from ._context import logging_context
 from ._metadata import LoggingMetadata, read_logging_metadata, set_logging_metadata
@@ -77,6 +78,58 @@ def _resolve_positional_index(func: Callable[..., Any], param: str) -> int | Non
     return None
 
 
+def _signature_can_receive_context(func: Callable[..., Any], param: str) -> bool:
+    """Return whether *func*'s signature could ever receive the context argument.
+
+    Used at decoration time to detect an *ineffective* ``@with_context``: the
+    Azure Functions worker injects the invocation ``Context`` object only when
+    the handler signature declares the parameter (see
+    ``azure-functions-python-worker`` ``FunctionInfo.is_context_required``), so a
+    handler that never declares *param* can never have context injected and the
+    decorator silently no-ops.
+
+    Returns ``True`` (i.e. *do not warn*) when:
+
+    * the signature cannot be introspected (be conservative — never warn on a
+      false positive);
+    * a parameter named *param* is present (any kind);
+    * a ``**kwargs`` (``VAR_KEYWORD``) parameter is present, which could carry
+      the context by keyword at call time.
+
+    Returns ``False`` only when the signature is introspectable and definitively
+    cannot receive *param*.
+    """
+    try:
+        parameters = inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        return True
+    if param in parameters:
+        return True
+    return any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values())
+
+
+def _check_context_detectable(func: Callable[..., Any], param: str, strict: bool) -> None:
+    """Warn (or raise, when *strict*) if ``@with_context`` can never inject context.
+
+    Runs once, at decoration time. Emits a :class:`RuntimeWarning` by default so
+    the misconfiguration is surfaced without breaking the app; raises
+    :class:`ValueError` when ``strict=True`` for CI-enforceable safety.
+    """
+    if _signature_can_receive_context(func, param):
+        return
+    handler_name = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
+    message = (
+        f"@with_context is ineffective on {handler_name!r}: its signature declares "
+        f"no {param!r} parameter, so the Azure Functions worker can never supply "
+        "the invocation context and context injection is a silent no-op. Add "
+        f"'{param}: func.Context' to the handler signature (or pass "
+        "param=... to match an existing parameter)."
+    )
+    if strict:
+        raise ValueError(message)
+    warnings.warn(message, RuntimeWarning, stacklevel=3)
+
+
 def _find_context_arg(
     param: str,
     positional_index: int | None,
@@ -133,7 +186,10 @@ def with_context(func: _F) -> _F: ...
 
 @overload
 def with_context(
-    *, param: str = ..., activate_trace_context: bool | None = ...
+    *,
+    param: str = ...,
+    activate_trace_context: bool | None = ...,
+    strict: bool = ...,
 ) -> Callable[[_F], _F]: ...
 
 
@@ -142,6 +198,7 @@ def with_context(
     *,
     param: str = _DEFAULT_PARAM,
     activate_trace_context: bool | None = None,
+    strict: bool = False,
 ) -> _F | Callable[[_F], _F]:
     """Decorator that automatically injects invocation context.
 
@@ -172,9 +229,20 @@ def with_context(
             ``trace_id``/``span_id`` (requires the ``[otel]`` extra; silent
             no-op otherwise). When ``None`` (default), the process-wide default
             configured via ``setup_logging(activate_trace_context=...)`` applies.
+        strict: When ``True``, raise :class:`ValueError` at decoration time if the
+            handler signature declares no ``param`` parameter (and cannot receive
+            it via ``**kwargs``), since context injection would silently no-op.
+            When ``False`` (default), the same condition emits a
+            :class:`RuntimeWarning` instead, so the app keeps running.
+
+    Warns:
+        RuntimeWarning: If the decorated handler cannot receive the context
+            argument, making injection an ineffective no-op. The Azure Functions
+            worker only supplies ``func.Context`` when the signature declares it.
     """
 
     def decorator(fn: _F) -> _F:
+        _check_context_detectable(fn, param, strict)
         if asyncio.iscoroutinefunction(fn):
             return _wrap_async(fn, param, activate_trace_context)
         return _wrap_sync(fn, param, activate_trace_context)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+import warnings
 
 import pytest
 
@@ -175,29 +176,104 @@ class TestAsync:
 
 
 class TestMissingContextParam:
-    """When the handler doesn't have the expected context param,
-    the decorator must not crash — just skip injection.
+    """When the handler cannot receive the expected context param, the decorator
+    must not crash the app — it skips injection and warns (or raises when strict).
     """
 
-    def test_no_context_param_does_not_crash(self) -> None:
-        @with_context
-        def handler(req: object) -> str:
-            # No context injected — vars stay None
-            assert invocation_id_var.get() is None
-            return "ok"
+    def test_no_context_param_warns_but_does_not_crash(self) -> None:
+        with pytest.warns(RuntimeWarning, match="ineffective"):
+
+            @with_context
+            def handler(req: object) -> str:
+                # No context injected — vars stay None
+                assert invocation_id_var.get() is None
+                return "ok"
 
         result = handler("req")
         assert result == "ok"
 
-    def test_wrong_param_name_does_not_crash(self) -> None:
-        @with_context(param="ctx")
-        def handler(req: object, context: object) -> str:
-            # 'ctx' not in signature → no injection
-            assert invocation_id_var.get() is None
-            return "ok"
+    def test_wrong_param_name_warns_but_does_not_crash(self) -> None:
+        with pytest.warns(RuntimeWarning, match="'ctx'"):
+
+            @with_context(param="ctx")
+            def handler(req: object, context: object) -> str:
+                # 'ctx' not in signature → no injection
+                assert invocation_id_var.get() is None
+                return "ok"
 
         result = handler("req", _MOCK_CONTEXT)
         assert result == "ok"
+
+    def test_kwargs_signature_does_not_warn(self) -> None:
+        # A **kwargs handler could receive the context by keyword at call time,
+        # so the decorator must not warn about an ineffective injection.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            @with_context
+            def handler(req: object, **kwargs: object) -> str:
+                return "ok"
+
+        assert handler("req") == "ok"
+
+    def test_declared_context_param_does_not_warn(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            @with_context
+            def handler(req: object, context: object) -> str:
+                return "ok"
+
+        assert handler("req", _MOCK_CONTEXT) == "ok"
+
+    def test_strict_raises_on_missing_context_param(self) -> None:
+        with pytest.raises(ValueError, match="ineffective"):
+
+            @with_context(strict=True)
+            def handler(req: object) -> str:  # pragma: no cover - never called
+                return "ok"
+
+    def test_strict_allows_declared_context_param(self) -> None:
+        @with_context(strict=True)
+        def handler(req: object, context: object) -> str:
+            return "ok"
+
+        assert handler("req", _MOCK_CONTEXT) == "ok"
+
+    def test_async_missing_context_param_warns(self) -> None:
+        with pytest.warns(RuntimeWarning, match="ineffective"):
+
+            @with_context
+            async def handler(req: object) -> str:
+                assert invocation_id_var.get() is None
+                return "ok"
+
+        assert asyncio.run(handler("req")) == "ok"
+
+    def test_async_strict_raises_on_missing_context_param(self) -> None:
+        with pytest.raises(ValueError, match="ineffective"):
+
+            @with_context(strict=True)
+            async def handler(req: object) -> str:  # pragma: no cover
+                return "ok"
+
+    def test_uninspectable_signature_does_not_warn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Some callables have no introspectable signature; the decorator must be
+        # conservative and never warn on a false positive when inspection fails.
+        import inspect
+
+        def _raise(_func: object) -> object:
+            raise ValueError("no signature")
+
+        monkeypatch.setattr(inspect, "signature", _raise)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            @with_context
+            def handler(req: object) -> str:
+                return "ok"
+
+        assert handler("req") == "ok"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Detects an **ineffective `@with_context`** — a handler decorated with `@with_context` but whose signature declares no context parameter, which the Azure Functions worker will never populate, making context injection a silent no-op.
- Default behavior: emit a `RuntimeWarning` at decoration time (import time) so the app keeps running but the misconfiguration is surfaced.
- Opt-in `strict=True` raises `ValueError` for CI-enforceable safety.
- Conservative: signatures that accept `**kwargs`, already declare the param, or cannot be introspected are left untouched (no false positives).

## Details
- New `_signature_can_receive_context()` and `_check_context_detectable()` in `_decorator.py`, invoked once inside `decorator(fn)`.
- Added `strict: bool = False` to `with_context()` (+ overload + docstring `Args`/`Warns`).
- README note in the Invocation context section documenting the requirement, the warning, `strict=True`, and `param=`.

## Testing
- `make lint` — passed
- `make typecheck` (mypy) — Success, no issues
- `hatch run pytest --cov` — 96.83% total coverage (≥95%), `_decorator.py` fully covered
- Added 8 tests to `TestMissingContextParam` covering warn/no-warn/strict/async/uninspectable paths

Closes #378