### PR TITLE
feat(context): support extra_context_vars in use_record_factory mode

### DIFF
--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -44,6 +44,33 @@ def _check_cold_start() -> bool:
     return False
 
 
+def _validate_extra_context_vars(
+    extra_context_vars: dict[str, contextvars.ContextVar[Any]] | None,
+) -> dict[str, contextvars.ContextVar[Any]]:
+    """Validate and copy user *extra_context_vars*, rejecting built-in collisions.
+
+    Shared by :class:`ContextFilter` and :func:`_install_context_factory` so both
+    context-injection strategies enforce the identical collision rule: a
+    user-supplied field name must not shadow one of the built-in context fields
+    (:data:`_CONTEXT_FIELD_NAMES`).
+
+    Returns a shallow copy of the mapping so later caller mutations do not affect
+    the stored variables.
+
+    Raises:
+        ValueError: If any field name collides with a built-in context field.
+    """
+    extra = extra_context_vars or {}
+    collisions = set(extra) & set(_CONTEXT_FIELD_NAMES)
+    if collisions:
+        msg = (
+            "extra_context_vars field names collide with built-in "
+            f"context fields: {', '.join(sorted(collisions))}"
+        )
+        raise ValueError(msg)
+    return dict(extra)
+
+
 class ContextFilter(logging.Filter):
     """Logging filter that copies contextvars values onto LogRecord attributes.
 
@@ -79,15 +106,7 @@ class ContextFilter(logging.Filter):
                 Field names must not collide with the built-in context fields.
         """
         super().__init__()
-        extra = extra_context_vars or {}
-        collisions = set(extra) & set(self.CONTEXT_FIELDS)
-        if collisions:
-            msg = (
-                "extra_context_vars field names collide with built-in "
-                f"context fields: {', '.join(sorted(collisions))}"
-            )
-            raise ValueError(msg)
-        self._extra_context_vars = dict(extra)
+        self._extra_context_vars = _validate_extra_context_vars(extra_context_vars)
 
     def filter(self, record: logging.LogRecord) -> bool:
         """Add context fields to the log record. Always returns True."""
@@ -331,7 +350,9 @@ _CONTEXT_FACTORY_MARKER = "_azure_functions_logging_context_factory"
 _CONTEXT_FACTORY_PREVIOUS = "_azure_functions_logging_previous_factory"
 
 
-def _install_context_factory() -> None:
+def _install_context_factory(
+    extra_context_vars: dict[str, contextvars.ContextVar[Any]] | None = None,
+) -> None:
     """Install a global LogRecordFactory that injects context into every LogRecord.
 
     This is an alternative to ``ContextFilter`` that guarantees context fields
@@ -356,7 +377,19 @@ def _install_context_factory() -> None:
 
     This function is idempotent for repeated direct calls while the currently
     active ``LogRecordFactory`` is the context factory installed by this package.
+
+    Args:
+        extra_context_vars: Optional mapping of ``field_name -> ContextVar``
+            whose current values are copied onto every record alongside the
+            built-in context fields, mirroring :class:`ContextFilter`. Field
+            names must not collide with the built-in context fields.
+
+    Raises:
+        ValueError: If any *extra_context_vars* field name collides with a
+            built-in context field. Validation runs before any global state is
+            mutated, so an invalid call installs nothing.
     """
+    extra = _validate_extra_context_vars(extra_context_vars)
     current_factory = logging.getLogRecordFactory()
     if getattr(current_factory, _CONTEXT_FACTORY_MARKER, False):
         return
@@ -371,6 +404,8 @@ def _install_context_factory() -> None:
         record.span_id = span_id_var.get()
         record.cold_start = cold_start_var.get()
         record.host_instance_id = get_host_instance_id()
+        for field_name, var in extra.items():
+            setattr(record, field_name, var.get())
         return record
 
     setattr(context_record_factory, _CONTEXT_FACTORY_MARKER, True)

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -117,11 +117,11 @@ def setup_logging(
             overwritten by the filter at handler dispatch time. Defaults to
             False to preserve the existing handler-filter-only behavior.
         extra_context_vars: Optional mapping of ``field_name -> ContextVar``
-            whose current values ``ContextFilter`` also copies onto each
-            LogRecord, alongside the four built-in context fields. Field names
-            must not collide with the built-in fields. Only applies to the
-            ``ContextFilter`` strategy; a warning is emitted if it is provided
-            when ``use_record_factory=True``.
+            whose current values are copied onto each LogRecord, alongside the
+            built-in context fields. Field names must not collide with the
+            built-in fields (raises ``ValueError`` otherwise). Applies to both
+            injection strategies: the default ``ContextFilter`` and the global
+            ``LogRecordFactory`` (``use_record_factory=True``).
         activate_trace_context: Sets the process-wide default that
             ``logging_context`` and ``with_context`` consult to attach the
             host's W3C trace context (via OpenTelemetry) — making OTel log
@@ -146,23 +146,12 @@ def setup_logging(
         msg = "format must be 'color' or 'json'"
         raise ValueError(msg)
 
-    # A caller-supplied extra_context_vars has no effect in record-factory
-    # mode (context is injected by the global LogRecordFactory, which does not
-    # read it). Silently dropping an explicit argument is a config footgun, so
-    # warn rather than ignore it. Only warn when the argument is actually set.
-    if use_record_factory and extra_context_vars:
-        warnings.warn(
-            "extra_context_vars is ignored when use_record_factory=True: context "
-            "is injected via the global LogRecordFactory, which does not read "
-            "extra_context_vars. Use the default ContextFilter mode "
-            "(use_record_factory=False) to apply them.",
-            stacklevel=2,
-        )
-
-    # Install the global LogRecordFactory only after argument validation,
-    # so an invalid call does not leave persistent global side effects.
+    # Install the global LogRecordFactory only after argument validation, so an
+    # invalid call (e.g. an extra_context_vars collision) does not leave
+    # persistent global side effects. In record-factory mode the factory now
+    # carries extra_context_vars too, so both modes honor user fields.
     if use_record_factory:
-        _install_context_factory()
+        _install_context_factory(extra_context_vars)
 
     with _configured_lock:
         # Only override the process-wide activation default when the caller

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -449,6 +449,45 @@ def test_install_context_factory_extra_collision_raises() -> None:
         logger.propagate = True
 
 
+def test_install_context_factory_injects_extra_context_vars() -> None:
+    """The factory copies user extra_context_vars onto every record (#380)."""
+    import contextvars
+
+    old_factory = logging.getLogRecordFactory()
+    tenant_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "tenant_id", default=None
+    )
+    token = tenant_var.set("acme")
+    try:
+        invocation_id_var.set("factory-inv")
+        _install_context_factory({"tenant_id": tenant_var})
+
+        record = logging.getLogRecordFactory()("test", logging.INFO, __file__, 1, "hi", (), None)
+        assert record.tenant_id == "acme"  # type: ignore[attr-defined]
+        # Built-in fields are still injected alongside the extra field.
+        assert record.invocation_id == "factory-inv"  # type: ignore[attr-defined]
+    finally:
+        logging.setLogRecordFactory(old_factory)
+        invocation_id_var.set(None)
+        tenant_var.reset(token)
+
+
+def test_install_context_factory_extra_collision_raises_value_error() -> None:
+    """extra_context_vars colliding with a built-in field raises ValueError and
+    installs no factory (#380)."""
+    import contextvars
+
+    old_factory = logging.getLogRecordFactory()
+    bad = {"invocation_id": contextvars.ContextVar("bad", default=None)}
+    try:
+        with pytest.raises(ValueError, match="collide with built-in"):
+            _install_context_factory(bad)
+        # No global side effect on the invalid call.
+        assert logging.getLogRecordFactory() is old_factory
+    finally:
+        logging.setLogRecordFactory(old_factory)
+
+
 def test_install_context_factory_with_logger_emit() -> None:
     """Context fields appear on records emitted through a real logger."""
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -775,17 +775,47 @@ def test_setup_logging_root_logger_propagation_untouched() -> None:
         root.propagate = saved_propagate
 
 
-def test_extra_context_vars_with_record_factory_warns() -> None:
-    # Passing extra_context_vars while use_record_factory=True has no effect;
-    # setup_logging must warn rather than silently drop the argument (#366).
-    extra = {"tenant": contextvars.ContextVar("tenant", default=None)}
+def test_extra_context_vars_with_record_factory_injects() -> None:
+    # extra_context_vars is now honored in record-factory mode too (#380): the
+    # global LogRecordFactory copies user fields onto every record, and
+    # setup_logging no longer warns that the argument is ignored.
+    tenant_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("tenant", default=None)
+    extra = {"tenant": tenant_var}
+    token = tenant_var.set("acme")
+    try:
+        with patch.dict(os.environ, {}, clear=True):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                setup_logging(
+                    logger_name="afl.test.factory_extra_ctx",
+                    use_record_factory=True,
+                    extra_context_vars=extra,
+                )
+        assert not [w for w in caught if "extra_context_vars is ignored" in str(w.message)]
+        record = logging.getLogRecordFactory()(
+            "afl.test.factory_extra_ctx", logging.INFO, __file__, 1, "hi", (), None
+        )
+        assert record.tenant == "acme"  # type: ignore[attr-defined]
+        # Built-in context fields are still injected alongside the extra field.
+        assert record.invocation_id is None  # type: ignore[attr-defined]
+    finally:
+        tenant_var.reset(token)
+
+
+def test_extra_context_vars_with_record_factory_collision_raises() -> None:
+    # A user field name that shadows a built-in context field must raise the
+    # same ValueError as ContextFilter mode, and install no global factory.
+    baseline_factory = logging.getLogRecordFactory()
+    extra = {"invocation_id": contextvars.ContextVar("bad", default=None)}
     with patch.dict(os.environ, {}, clear=True):
-        with pytest.warns(UserWarning, match="extra_context_vars is ignored"):
+        with pytest.raises(ValueError, match="collide with built-in"):
             setup_logging(
-                logger_name="afl.test.warn_extra_ctx",
+                logger_name="afl.test.factory_collision",
                 use_record_factory=True,
                 extra_context_vars=extra,
             )
+    # Invalid call left no persistent global side effect.
+    assert logging.getLogRecordFactory() is baseline_factory
 
 
 def test_extra_context_vars_without_record_factory_does_not_warn() -> None:


### PR DESCRIPTION
## Summary
Removes the deliberate asymmetry where user-supplied `extra_context_vars` were honored only in the default `ContextFilter` mode and **ignored** (with a warning) when `use_record_factory=True`. The global `LogRecordFactory` now snapshots `extra_context_vars` onto every record too, so users can get record-creation-time (cross-thread / queued-record) coverage **and** their own fields without a mode trade-off.

## Details
- `_install_context_factory()` now accepts `extra_context_vars` and injects each variable's current value onto every record, mirroring `ContextFilter`.
- New shared `_validate_extra_context_vars()` helper enforces the identical built-in-field **collision rule** (`ValueError`) for both strategies; `ContextFilter.__init__` now delegates to it.
- Validation runs **before** the global factory is installed, so an invalid call (collision) installs nothing — no persistent global side effect.
- `setup_logging()` passes `extra_context_vars` through in record-factory mode and the "extra_context_vars is ignored" warning is removed. Docstring updated to state both modes honor the argument.

## Acceptance checklist (from #380)
- [x] `use_record_factory=True` + `extra_context_vars` injects the user fields onto every record.
- [x] Collision with built-in fields raises the same `ValueError` as ContextFilter mode.
- [x] The `_setup.py` "ignored" warning is removed.
- [x] Parity tests: both modes inject identical built-in **and** extra fields.
- [x] `tests/test_setup.py` updated to reflect the new behavior (warn test → inject + collision tests).
- [x] Coverage stays >= 95%.

## Testing
- `make lint` + `make typecheck` — clean (mypy: no issues in 38 files)
- `make test` — **495 passed**, 5 skipped, coverage **96.48%** (>=95% gate)

Closes #380