### PR TITLE
feat(context): add background-thread invocation context propagation helper

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -42,7 +42,7 @@ The initial version (v0.1.0) did not provide the items below. Several have since
 - ~~`host.json` log level conflict warning~~ — **shipped in v0.2.0**
 - ~~Sampling or log volume control~~ — **shipped** (`SamplingFilter`)
 - ~~OpenTelemetry integration~~ — **partially shipped:** opt-in OpenTelemetry *log correlation* via the `[otel]` extra (`activate_trace_context=True`). Span creation / trace export remains a non-goal (see below).
-- Async context propagation across threads (still a non-goal; contextvars do not follow `ThreadPoolExecutor` / background threads)
+- Async context propagation across threads — **partially shipped:** opt-in, explicit propagation via `propagate_context()` for `ThreadPoolExecutor` / background threads (contextvars still do not follow threads *automatically*; implicit/monkeypatched instrumentation remains a non-goal)
 - Distributed tracing — creating, recording, or exporting spans (**permanent non-goal**; use OpenTelemetry or the Application Insights SDK)
 - Log aggregation or external backend integrations (still a non-goal)
 
@@ -246,7 +246,7 @@ inject_context(func_context)
 
 - Log sampling / volume control
 - `.catch()` decorator for exception logging
-- Async context propagation across threads
+- ~~Async context propagation across threads~~ — **shipped** (explicit `propagate_context()` helper)
 - Full OpenTelemetry correlation
 
 ## 12. Success Metrics

--- a/README.md
+++ b/README.md
@@ -317,6 +317,22 @@ Every capability below has a full how-to on the [documentation site](https://yeo
 
 → [Usage: context injection](https://yeongseon.dev/azure-functions-python/logging/usage/#3-context-injection-in-azure-functions) · [API: `with_context`](https://yeongseon.dev/azure-functions-python/logging/api/#with_context)
 
+### Background-thread context propagation
+
+Invocation context is carried via `contextvars`, which do **not** follow work handed to a `ThreadPoolExecutor` or a manually created `threading.Thread` — records emitted from those threads lose their `invocation_id`. `propagate_context()` binds the current invocation context to a callable so it stays correlated on the worker thread. Wrap the callable inside the invocation, immediately before submitting the work:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+from azure_functions_logging import logging_context, propagate_context
+
+with logging_context(context):
+    with ThreadPoolExecutor() as pool:
+        pool.submit(propagate_context(do_work, context=context), payload)
+```
+
+Passing `context=context` also propagates the Azure worker's `thread_local_storage.invocation_id` so the worker's own logging handler correlates too. This is explicit and opt-in: the library never monkeypatches `threading` / `concurrent.futures`, and propagation failures never crash the caller. It is **correlation only** — no spans are created or exported.
+
 ### Structured JSON output
 
 Pass `setup_logging(functions_formatter=JsonFormatter())` to emit Application Insights-ready NDJSON on host-managed handlers (or `format="json"` for standalone/CI). Extra fields land under `extra`; opt into `truncate_native_strings=True` to clip long string values.

--- a/docs/api.md
+++ b/docs/api.md
@@ -300,6 +300,38 @@ metadata = get_logging_metadata(handler)
 
 ::: azure_functions_logging.logging_context
 
+## propagate_context
+
+::: azure_functions_logging.propagate_context
+
+### Usage Notes
+
+- Binds the current invocation context to a callable so it can run on a
+  `ThreadPoolExecutor` worker or a manually created `threading.Thread`, which
+  `contextvars` do not reach on their own.
+- Wrap **inside** the invocation, immediately before submitting the work; the
+  context is snapshotted at wrap time.
+- Pass `context=context` to also propagate the Azure worker's
+  `thread_local_storage.invocation_id`; propagation failures are silent and never
+  crash the caller.
+
+### Example: ThreadPoolExecutor
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+import azure.functions as func
+from azure_functions_logging import logging_context, propagate_context
+
+
+def handler(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    with logging_context(context):
+        with ThreadPoolExecutor() as pool:
+            future = pool.submit(propagate_context(do_work, context=context), payload)
+            future.result()  # log records from do_work carry the invocation context
+    return func.HttpResponse("ok")
+```
+
 ## reset_context
 
 ::: azure_functions_logging.reset_context

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -6,6 +6,7 @@ from ._context import (
     ContextTokens,
     inject_context,
     logging_context,
+    propagate_context,
     reset_context,
     restore_context,
 )
@@ -25,6 +26,7 @@ __all__ = [
     "inject_context",
     "JsonFormatter",
     "logging_context",
+    "propagate_context",
     "RedactionFilter",
     "reset_context",
     "restore_context",

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 import contextvars
+import functools
 import logging
 import threading
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, ParamSpec, TypeVar
 
 from ._constants import _CONTEXT_FIELD_NAMES
 from ._host_instance import get_host_instance_id
@@ -238,6 +239,117 @@ def restore_context(tokens: ContextTokens) -> None:
     """
     for var, token in tokens.items():
         var.reset(token)
+
+
+# --- Background-thread context propagation ---
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+#: Invocation context variables propagated by :func:`propagate_context`.
+_PROPAGATED_CONTEXT_VARS: tuple[contextvars.ContextVar[Any], ...] = (
+    invocation_id_var,
+    function_name_var,
+    trace_id_var,
+    span_id_var,
+    cold_start_var,
+)
+
+_MISSING = object()
+
+
+def propagate_context(
+    func: Callable[_P, _R],
+    *,
+    context: Any = None,
+) -> Callable[_P, _R]:
+    """Bind the current invocation context to *func* for background-thread execution.
+
+    Invocation context is stored in :mod:`contextvars`, which do **not** propagate
+    to :class:`~concurrent.futures.ThreadPoolExecutor` workers or manually created
+    :class:`threading.Thread` targets. Wrapping a callable with
+    ``propagate_context`` snapshots the current invocation context fields
+    (``invocation_id``, ``function_name``, ``trace_id``, ``span_id``,
+    ``cold_start``) **at wrap time** and re-applies them inside the wrapper when
+    it later runs on another thread, then restores the previous values on exit so
+    pooled threads never leak context between tasks.
+
+    Wrap the callable inside the invocation whose context should be propagated,
+    immediately before handing work to a thread or executor::
+
+        from concurrent.futures import ThreadPoolExecutor
+
+        def handler(req, context):
+            with logging_context(context):
+                with ThreadPoolExecutor() as pool:
+                    pool.submit(propagate_context(do_work, context=context), payload)
+
+    When an Azure Functions ``context`` object is supplied, the worker's
+    ``thread_local_storage.invocation_id`` is also set for the duration of the
+    call (and restored afterwards) so the worker's own logging handler correlates
+    records emitted from the background thread. This is best-effort and
+    duck-typed: any missing attribute or error is silently ignored (Principle 3:
+    context propagation failures never crash the caller). No ``azure-functions``
+    import is required.
+
+    Args:
+        func: The callable to run on a background thread. Called with whatever
+            positional/keyword arguments the returned wrapper receives.
+        context: Optional Azure Functions context object (``func.Context``). When
+            provided, its ``invocation_id`` is propagated to the worker's
+            ``thread_local_storage`` in addition to the ``contextvars`` snapshot.
+
+    Returns:
+        A wrapper around *func* that applies the snapshotted context on entry and
+        restores the previous state on exit. Reusable and concurrency-safe: it may
+        be submitted to multiple threads simultaneously.
+    """
+    snapshot: tuple[tuple[contextvars.ContextVar[Any], Any], ...] = tuple(
+        (var, var.get()) for var in _PROPAGATED_CONTEXT_VARS
+    )
+
+    inv_id: Any = None
+    tls: Any = None
+    if context is not None:
+        try:
+            inv_id = getattr(context, "invocation_id", None)
+            tls = getattr(context, "thread_local_storage", None)
+        except Exception:  # nosec B110 — Principle 3: context failures are silent
+            inv_id = None
+            tls = None
+
+    @functools.wraps(func)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        tokens: list[tuple[contextvars.ContextVar[Any], contextvars.Token[Any]]] = []
+        previous_tls_invocation_id: Any = _MISSING
+        tls_was_set = False
+        try:
+            for var, value in snapshot:
+                tokens.append((var, var.set(value)))
+            if tls is not None and inv_id is not None:
+                try:
+                    previous_tls_invocation_id = getattr(tls, "invocation_id", _MISSING)
+                    tls.invocation_id = inv_id
+                    tls_was_set = True
+                except Exception:  # nosec B110 — Principle 3: context failures are silent
+                    tls_was_set = False
+            return func(*args, **kwargs)
+        finally:
+            if tls_was_set:
+                try:
+                    if previous_tls_invocation_id is _MISSING:
+                        try:
+                            del tls.invocation_id
+                        except Exception:  # nosec B110 — Principle 3: silent
+                            tls.invocation_id = None
+                    else:
+                        tls.invocation_id = previous_tls_invocation_id
+                except Exception:  # nosec B110 — Principle 3: context failures are silent
+                    pass
+            for var, token in reversed(tokens):
+                var.reset(token)
+
+    return wrapper
 
 
 # Process-wide default for OpenTelemetry trace-context activation. Toggled by

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -20,6 +20,7 @@ from azure_functions_logging._context import (
     inject_context,
     invocation_id_var,
     logging_context,
+    propagate_context,
     reset_context,
     restore_context,
     span_id_var,
@@ -673,3 +674,166 @@ def test_reset_context_clears_span_id() -> None:
     span_id_var.set("00f067aa0ba902b7")
     reset_context()
     assert span_id_var.get() is None
+
+
+def test_propagate_context_carries_contextvars_to_worker_thread() -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    invocation_id_var.set("inv-abc")
+    function_name_var.set("my_func")
+    trace_id_var.set("4bf92f3577b34da6a3ce929d0e0e4736")
+    span_id_var.set("00f067aa0ba902b7")
+    cold_start_var.set(True)
+
+    def worker() -> dict[str, Any]:
+        return {
+            "invocation_id": invocation_id_var.get(),
+            "function_name": function_name_var.get(),
+            "trace_id": trace_id_var.get(),
+            "span_id": span_id_var.get(),
+            "cold_start": cold_start_var.get(),
+        }
+
+    wrapped = propagate_context(worker)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        # Prove the pool thread has no context of its own first.
+        assert pool.submit(worker).result()["invocation_id"] is None
+        result = pool.submit(wrapped).result()
+
+    assert result == {
+        "invocation_id": "inv-abc",
+        "function_name": "my_func",
+        "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+        "span_id": "00f067aa0ba902b7",
+        "cold_start": True,
+    }
+
+
+def test_propagate_context_passes_arguments_through() -> None:
+    def add(a: int, b: int, *, c: int = 0) -> int:
+        return a + b + c
+
+    wrapped = propagate_context(add)
+    assert wrapped(1, 2, c=3) == 6
+
+
+def test_propagate_context_restores_previous_contextvars_in_pooled_thread() -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        invocation_id_var.set("inv-1")
+        pool.submit(propagate_context(lambda: None)).result()
+        # The pooled thread must not leak "inv-1" into the next task.
+        leaked = pool.submit(invocation_id_var.get).result()
+
+    assert leaked is None
+
+
+def test_propagate_context_snapshots_at_wrap_time() -> None:
+    invocation_id_var.set("wrap-time")
+    wrapped = propagate_context(invocation_id_var.get)
+    invocation_id_var.set("call-time")
+    assert wrapped() == "wrap-time"
+
+
+def test_propagate_context_sets_azure_thread_local_invocation_id() -> None:
+    tls = SimpleNamespace()
+    context = SimpleNamespace(invocation_id="inv-xyz", thread_local_storage=tls)
+
+    def worker() -> str | None:
+        return getattr(tls, "invocation_id", None)
+
+    wrapped = propagate_context(worker, context=context)
+    assert wrapped() == "inv-xyz"
+    # Restored (deleted) after the call because it was previously absent.
+    assert not hasattr(tls, "invocation_id")
+
+
+def test_propagate_context_restores_previous_thread_local_invocation_id() -> None:
+    tls = SimpleNamespace(invocation_id="pre-existing")
+    context = SimpleNamespace(invocation_id="inv-new", thread_local_storage=tls)
+
+    seen: list[str | None] = []
+    wrapped = propagate_context(lambda: seen.append(tls.invocation_id), context=context)
+    wrapped()
+
+    assert seen == ["inv-new"]
+    assert tls.invocation_id == "pre-existing"
+
+
+def test_propagate_context_ignores_context_without_thread_local() -> None:
+    context = SimpleNamespace(invocation_id="inv-1")  # no thread_local_storage
+    invocation_id_var.set("ctxvar")
+    wrapped = propagate_context(invocation_id_var.get, context=context)
+    assert wrapped() == "ctxvar"
+
+
+def test_propagate_context_thread_local_failure_is_silent() -> None:
+    class Boom:
+        @property
+        def invocation_id(self) -> str:
+            raise RuntimeError("boom")
+
+        @invocation_id.setter
+        def invocation_id(self, value: str) -> None:
+            raise RuntimeError("boom")
+
+    context = SimpleNamespace(invocation_id="inv-1", thread_local_storage=Boom())
+    invocation_id_var.set("ctxvar")
+    wrapped = propagate_context(invocation_id_var.get, context=context)
+    # Must not raise despite the thread-local setter blowing up.
+    assert wrapped() == "ctxvar"
+
+
+def test_propagate_context_reusable_across_concurrent_threads() -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    invocation_id_var.set("shared")
+    wrapped = propagate_context(invocation_id_var.get)
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = [f.result() for f in [pool.submit(wrapped) for _ in range(8)]]
+    assert results == ["shared"] * 8
+
+
+def test_propagate_context_context_attribute_access_failure_is_silent() -> None:
+    class BadContext:
+        @property
+        def invocation_id(self) -> str:
+            raise RuntimeError("boom")
+
+    invocation_id_var.set("ctxvar")
+    wrapped = propagate_context(invocation_id_var.get, context=BadContext())
+    assert wrapped() == "ctxvar"
+
+
+def test_propagate_context_thread_local_delete_failure_falls_back_to_none() -> None:
+    class NoDelTLS:
+        def __delattr__(self, name: str) -> None:
+            raise AttributeError("cannot delete")
+
+    tls = NoDelTLS()  # invocation_id initially absent
+    context = SimpleNamespace(invocation_id="inv-1", thread_local_storage=tls)
+    wrapped = propagate_context(lambda: None, context=context)
+    wrapped()
+    # del failed during restore, so it falls back to setting None.
+    assert getattr(tls, "invocation_id") is None  # noqa: B009
+
+
+def test_propagate_context_thread_local_restore_failure_is_silent() -> None:
+    class RestoreBoomTLS:
+        def __init__(self) -> None:
+            object.__setattr__(self, "invocation_id", "orig")
+            object.__setattr__(self, "_calls", 0)
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            calls = object.__getattribute__(self, "_calls")
+            object.__setattr__(self, "_calls", calls + 1)
+            if calls >= 1:  # fail on the restore (second) assignment
+                raise RuntimeError("boom")
+            object.__setattr__(self, name, value)
+
+    tls = RestoreBoomTLS()
+    context = SimpleNamespace(invocation_id="inv-new", thread_local_storage=tls)
+    wrapped = propagate_context(lambda: None, context=context)
+    # Restore raising must not propagate out of the wrapper.
+    wrapped()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -91,6 +91,7 @@ def test_public_api_exports() -> None:
         "get_logger",
         "inject_context",
         "logging_context",
+        "propagate_context",
         "reset_context",
         "restore_context",
         "setup_logging",

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -19,6 +19,7 @@ class TestAPISurface:
             "get_logger",
             "inject_context",
             "logging_context",
+            "propagate_context",
             "reset_context",
             "restore_context",
             "setup_logging",
@@ -45,6 +46,7 @@ class TestAPISurface:
             get_logging_metadata,
             inject_context,
             logging_context,
+            propagate_context,
             reset_context,
             restore_context,
         )


### PR DESCRIPTION
## Summary

Adds `propagate_context()` — an explicit, opt-in helper that binds the current invocation context to a callable so it stays correlated when run on a `ThreadPoolExecutor` worker or a manually created `threading.Thread`. `contextvars` do not follow work handed to background threads, so records emitted there previously lost their `invocation_id`.

- Snapshots the five invocation context fields (`invocation_id`, `function_name`, `trace_id`, `span_id`, `cold_start`) **at wrap time** and re-applies them inside the wrapper, restoring the previous values on exit so pooled threads never leak context between tasks.
- Per-call `set`/`reset` (not a reusable `copy_context()`) keeps the wrapper **concurrency-safe and reusable** across simultaneous threads.
- When an Azure Functions `context` is supplied, also sets the worker's `thread_local_storage.invocation_id` for the duration of the call and restores it afterwards, so the worker's own logging handler correlates too.
- All Azure access is duck-typed — **no `azure-functions` import**. Propagation failures are silent and never crash the caller.
- Correlation only: no spans created or exported; no monkeypatching of `threading` / `concurrent.futures`.

## Acceptance checklist (from #379)

- [x] Propagates all built-in context fields into a callable on a background thread
- [x] `ThreadPoolExecutor.submit`-style usage documented and tested
- [x] Optional Azure worker `thread_local_storage.invocation_id` propagation
- [x] Propagation failures never crash the caller
- [x] No runtime dependency on `azure-functions`
- [x] README section + example; PRD non-goal updated (`PRD.md:45`, `PRD.md:249`)
- [x] Coverage stays >= 95% (96.61%)

## Validation

- `make lint` — clean
- `make typecheck` — clean (mypy, 38 files)
- `make test` — 504 passed, 5 skipped; total coverage 96.61%

Closes #379