### PR TITLE
docs(setup): define and document setup_logging() reconfiguration semantics

### DIFF
--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -89,8 +89,36 @@ def setup_logging(
       ``propagate`` flag is set to ``False`` so records are not also emitted
       by an ancestor (e.g. root) handler, which would double-log.
 
-    This function is idempotent per ``logger_name`` — calling it multiple times
-    for the same logger has no additional effect.
+    **Reconfiguration (calling ``setup_logging()`` more than once).**
+    Repeat calls are safe and never double-install filters or handlers. The
+    exact contract depends on the detected environment:
+
+    - **Standalone local mode** is fully idempotent per ``logger_name``: state
+      is tracked in a process-wide set, so the *first* call for a given
+      ``logger_name`` wins and later calls for that same name return early —
+      ``level``, ``format``, and the added handler are applied only once.
+      Configure a different ``logger_name`` to set up an additional logger.
+    - **Azure / Core Tools mode** is idempotent per
+      ``(logger_name, use_record_factory)`` at the *handler* level: each root
+      handler is given the ``ContextFilter`` (and ``functions_formatter``, if
+      supplied) exactly once, tracked by a ``WeakSet``. Repeat calls therefore
+      *recover* by picking up any handlers the host attached after the previous
+      call, without duplicating filters. The root logger's level and handler
+      list are never modified (``host.json`` owns the level).
+
+    **Switching ``use_record_factory`` between calls.** Enabling it
+    (``False`` -> ``True``) installs the global ``LogRecordFactory`` and strips
+    any ``ContextFilter`` this package previously installed on the target and
+    root loggers, so context is injected by exactly one mechanism. The two
+    modes keep isolated per-signature state, so a later ``ContextFilter`` call
+    never reuses a factory-mode instance (or vice versa). Switching back
+    (``True`` -> ``False``) installs a fresh ``ContextFilter`` but does **not**
+    uninstall the already-installed global factory; prefer a single, consistent
+    ``use_record_factory`` value per process.
+
+    **Switching ``activate_trace_context``.** A bare ``setup_logging()`` (the
+    default ``activate_trace_context=None``) leaves the previously configured
+    activation default untouched; pass ``True``/``False`` to change it.
 
     Args:
         level: Logging level for local development. Ignored in Azure/Core Tools.

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -813,3 +813,63 @@ def test_record_factory_without_extra_context_vars_does_not_warn() -> None:
                 use_record_factory=True,
             )
     assert not [w for w in caught if "extra_context_vars is ignored" in str(w.message)]
+
+
+# ---------------------------------------------------------------------------
+# #381: reconfiguration semantics — repeat-call contract pinning
+# ---------------------------------------------------------------------------
+def test_azure_repeat_calls_do_not_modify_root_level_or_handlers() -> None:
+    """In Azure mode, repeated setup_logging() calls must leave the root logger's
+    level and handler list untouched (host.json owns the level)."""
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    original_filters = root.filters[:]
+    original_level = root.level
+    try:
+        handler = logging.StreamHandler()
+        root.handlers[:] = [handler]
+        root.setLevel(logging.WARNING)
+        handlers_snapshot = root.handlers[:]
+
+        with patch.dict(os.environ, {"FUNCTIONS_WORKER_RUNTIME": "python"}, clear=True):
+            setup_logging(level=logging.DEBUG)
+            setup_logging(level=logging.DEBUG)
+
+        assert root.level == logging.WARNING  # level never changed
+        assert root.handlers == handlers_snapshot  # handler list never changed
+    finally:
+        root.handlers[:] = original_handlers
+        root.filters[:] = original_filters
+        root.setLevel(original_level)
+
+
+def test_switch_back_to_filter_mode_leaves_global_factory_installed() -> None:
+    """Documented caveat: True -> False installs a fresh ContextFilter but does
+    NOT uninstall the already-installed global LogRecordFactory."""
+    from azure_functions_logging._context import _CONTEXT_FACTORY_MARKER
+
+    name_true = "afl.test.reconfig.factory"
+    name_false = "afl.test.reconfig.filter"
+    for n in (name_true, name_false):
+        lg = logging.getLogger(n)
+        lg.handlers.clear()
+        lg.filters.clear()
+
+    with patch.dict(os.environ, {}, clear=True):
+        setup_logging(logger_name=name_true, use_record_factory=True)
+        assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False) is True
+        # A subsequent filter-mode call for a different logger does not tear the
+        # global factory back down.
+        setup_logging(logger_name=name_false, use_record_factory=False)
+
+    assert getattr(logging.getLogRecordFactory(), _CONTEXT_FACTORY_MARKER, False) is True
+    filter_installed = any(
+        type(f) is ContextFilter for f in logging.getLogger(name_false).filters
+    ) or any(
+        type(f) is ContextFilter for h in logging.getLogger(name_false).handlers for f in h.filters
+    )
+    assert filter_installed
+    for n in (name_true, name_false):
+        lg = logging.getLogger(n)
+        lg.handlers.clear()
+        lg.filters.clear()


### PR DESCRIPTION
## Summary

Pins down and documents the previously under-specified behavior of calling `setup_logging()` more than once (repeated imports, test setups, warm vs cold starts).

- **Standalone local mode** — fully idempotent per `logger_name`; the first call for a name wins, later calls for that name return early.
- **Azure / Core Tools mode** — idempotent per `(logger_name, use_record_factory)` at the *handler* level; repeat calls recover by picking up host-added handlers without duplicating filters. Root logger level and handler list are never modified.
- **Switching `use_record_factory`** — enabling it installs the global `LogRecordFactory` and strips previously-installed `ContextFilter`s so exactly one mechanism injects context; switching back installs a fresh filter but does **not** uninstall the global factory (now a documented caveat — prefer a single value per process).
- **`activate_trace_context`** — a bare `setup_logging()` leaves the stored default untouched.

The full contract now lives in the `setup_logging()` docstring (rendered on the docs site via mkdocstrings).

## Tests

Most edges were already pinned (`test_azure_setup_does_not_duplicate_filter_on_repeated_calls`, `..._isolated_filter_state`, upgrade-to-record-factory removal). This PR adds the two remaining gaps:

- `test_azure_repeat_calls_do_not_modify_root_level_or_handlers`
- `test_switch_back_to_filter_mode_leaves_global_factory_installed`

## Acceptance checklist (from #381)

- [x] Document the exact reconfiguration contract (handlers, filters, level, format)
- [x] Define behavior when `use_record_factory` flips between calls
- [x] Define behavior switching `logger_name` (standalone) vs root (Azure)
- [x] `ContextFilter` never double-installed on the same handler
- [x] Tests pinning: no duplicate filters/handlers; root level/handlers unchanged in Azure mode
- [x] Docstring section describing safe re-invocation
- [x] Coverage stays >= 95% (96.47%)

## Validation

- `make lint` / `make typecheck` — clean
- `make test` — 494 passed, 5 skipped; total coverage 96.47%

Closes #381