### PR TITLE
chore(ci): group dependabot updates + auto-merge patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,11 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "actions/download-artifact"
         update-types: ["version-update:semver-major"]
+      # azure/login is a fleet-wide canonical pin (tools/lint_release_workflows.py
+      # CANONICAL_ACTIONS). A per-repo Dependabot bump breaks the canonical-pin
+      # lint (tests/test_release_workflow_pins.py), so version bumps are adopted
+      # deliberately as a coordinated fleet change, not by Dependabot.
+      - dependency-name: "azure/login"
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,13 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -49,3 +56,10 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "actions/download-artifact"
         update-types: ["version-update:semver-major"]
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,10 +33,10 @@ updates:
     # Let freshly-published versions age before Dependabot proposes them, so a
     # compromised release has time to be yanked/flagged (supply-chain hardening).
     cooldown:
+      # github-actions does not follow semver the way registry packages do, so
+      # Dependabot only supports a flat default-days cooldown here (the
+      # semver-*-days keys are rejected for this ecosystem).
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
       include:
         - "*"
     commit-message:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
 
       - name: Enable auto-merge for patch/minor updates
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch/minor updates
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automates recurring dependabot toil.

## What
- Group dependabot minor/patch updates (pip + github-actions) into single PRs — fixes the codeql `init`/`analyze` version-mismatch failures caused by split PRs.
- Add `dependabot-automerge.yml`: enables GitHub native auto-merge (squash) for **patch/minor** dependabot PRs once required CI is green.

## Why
Major updates are intentionally excluded — they stay as individual PRs for manual review (e.g. artifact v4→v8, langgraph-sdk bumps that break tests).

## Follow-up (manual, per repo)
- Ensure branch protection has **required status checks** so auto-merge waits for CI.