### PR TITLE
fix(ci): reset artifact action pins to canonical v4 + Dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,14 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 10
+    ignore:
+      # actions/upload-artifact + actions/download-artifact are managed as a v4
+      # "canonical pair" by tools/lint_release_workflows.py (release-gate drift
+      # lint). download-artifact v5+ ships breaking behavior (Node 24 runner
+      # minimum, digest-mismatch fail-by-default) that would break the gate lint
+      # and CI, so major bumps are adopted deliberately, not by Dependabot.
+      # See yeongseon/azure-functions-validation-python#306.
+      - dependency-name: "actions/upload-artifact"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "actions/download-artifact"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -184,7 +184,7 @@ jobs:
           cat cert/certification.json
 
       - name: Upload certification record
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: azure-cert
           path: cert/
@@ -193,7 +193,7 @@ jobs:
 
       - name: Upload e2e report
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: e2e-report/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -75,7 +75,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: dist/
@@ -120,7 +120,7 @@ jobs:
           python-version: "3.10"
 
       - name: Download candidate wheel
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: candidate-dist
@@ -182,7 +182,7 @@ jobs:
           azurite --version
 
       - name: Download candidate wheel
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: candidate-dist
@@ -252,7 +252,7 @@ jobs:
           echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
 
       - name: Download certification record
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: azure-cert
           path: cert
@@ -299,7 +299,7 @@ jobs:
       id-token: write
     steps:
       - name: Download tested distribution artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
## Context
Dependabot bumped `actions/upload-artifact`→v7.0.1 and `actions/download-artifact`→v8.0.1 in the release-gate workflows, but `tools/lint_release_workflows.py` pins both to the canonical **v4** pair. This broke `tests/test_release_workflow_pins.py::test_repo_release_workflows_are_clean` on `main` (and cascaded to every stale PR).

## Changes
- Reset `publish-pypi.yml` and `e2e-azure.yml` artifact-action pins to the canonical v4 SHAs (matches `CANONICAL_ACTIONS`).
- Add a Dependabot `ignore` for semver-major bumps of both actions in `.github/dependabot.yml`, mirroring the fleet pattern (langgraph). Major bumps of the artifact pair are adopted deliberately, not reopened automatically.
- `sbom.yml` intentionally left at v7.0.1 — it is outside the release-gate lint scope, consistent with sibling repos.

## Verification
- `python3 tools/lint_release_workflows.py` → clean (exit 0)
- `make check` → lint + typecheck clean
- `make test` → 527 passed, 97.07% coverage