### PR TITLE
docs: add "How correlation works" mechanism page and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,9 +479,35 @@ with logging_context(context):
 **Proves:** your existing OpenTelemetry log records inherit the host invocation's `trace_id` / `span_id`. **Does not prove:** a span was created or exported — this is correlation, not tracing (see [OpenTelemetry trace correlation](#opentelemetry-trace-correlation)).
 </details>
 
+<details>
+<summary><strong>Logs from a background thread have no <code>invocation_id</code></strong></summary>
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+from azure_functions_logging import logging_context, propagate_context
+
+with logging_context(context):
+    with ThreadPoolExecutor() as pool:
+        pool.submit(propagate_context(do_work, context=context), payload)
+```
+
+**Likely cause:** `contextvars` do not follow work handed to a new thread or `ThreadPoolExecutor`, so records emitted there lose the bound context. **Proves:** wrapping the callable with `propagate_context()` keeps `invocation_id` correlated on the worker thread. **Does not prove:** anything about threads you did not wrap — propagation is explicit and opt-in.
+
+→ [How correlation works: background threads](https://yeongseon.dev/azure-functions-python/logging/how-correlation-works/#4-why-background-threads-lose-the-id) · [Background-thread context propagation](#background-thread-context-propagation)
+</details>
+
+<details>
+<summary><strong>My <code>invocation_id</code> doesn't match Application Insights <code>operation_Id</code></strong></summary>
+
+These are **different identifiers with different owners.** `invocation_id` is this library's field — always present, one per invocation, read from the host's gRPC contract. `operation_Id` is owned by the host/ingestion pipeline and the W3C trace context. A record can carry an `invocation_id` while `operation_Id` is absent or different; that is expected, not a bug.
+
+→ [How correlation works: vs Application Insights](https://yeongseon.dev/azure-functions-python/logging/how-correlation-works/#5-relationship-to-application-insights-operation_id) · [OpenTelemetry trace correlation](#opentelemetry-trace-correlation)
+</details>
+
 ## Documentation
 
 - Full docs: [yeongseon.dev/azure-functions-python/logging](https://yeongseon.dev/azure-functions-python/logging/)
+- [How Correlation Works](https://yeongseon.dev/azure-functions-python/logging/how-correlation-works/) — how `invocation_id` flows from the host to every log record
 - [Configuration reference](https://yeongseon.dev/azure-functions-python/logging/configuration/)
 - [Troubleshooting guide](https://yeongseon.dev/azure-functions-python/logging/troubleshooting/)
 - [API reference](https://yeongseon.dev/azure-functions-python/logging/api/)

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ with logging_context(context):
 <details>
 <summary><strong>My <code>invocation_id</code> doesn't match Application Insights <code>operation_Id</code></strong></summary>
 
-These are **different identifiers with different owners.** `invocation_id` is this library's field — always present, one per invocation, read from the host's gRPC contract. `operation_Id` is owned by the host/ingestion pipeline and the W3C trace context. A record can carry an `invocation_id` while `operation_Id` is absent or different; that is expected, not a bug.
+These are **different identifiers with different owners.** `invocation_id` is this library's field — present on every record emitted within a bound invocation context (`logging_context()` / `inject_context()`), one per invocation, read from the host's gRPC contract. It can be absent outside that context — for example on records from background threads that did not call `propagate_context()`. `operation_Id` is owned by the host/ingestion pipeline and the W3C trace context. A record can carry an `invocation_id` while `operation_Id` is absent or different; that is expected, not a bug.
 
 → [How correlation works: vs Application Insights](https://yeongseon.dev/azure-functions-python/logging/how-correlation-works/#5-relationship-to-application-insights-operation_id) · [OpenTelemetry trace correlation](#opentelemetry-trace-correlation)
 </details>

--- a/docs/how-correlation-works.md
+++ b/docs/how-correlation-works.md
@@ -4,7 +4,7 @@ How `azure-functions-logging` turns a per-invocation identifier into the `invoca
 
 !!! note "Scope of this page"
     Claims here are limited to the public gRPC proto contract and behavior you can observe from user code — no host-internal narration.
-    External citations are pinned to a specific tag or commit, not a moving branch.
+    GitHub source links are pinned to a specific tag or commit, not a moving branch. External specification and vendor references (Python docs, W3C, Microsoft Learn) link to their canonical/stable URLs, which are versioned or long-lived rather than commit-pinned.
     Links verified 2026-08-26.
 
 ## 1. Where `invocation_id` comes from

--- a/docs/how-correlation-works.md
+++ b/docs/how-correlation-works.md
@@ -1,0 +1,82 @@
+# How Correlation Works
+
+How `azure-functions-logging` turns a per-invocation identifier into the `invocation_id` on every log record, and how that relates to Application Insights correlation.
+
+!!! note "Scope of this page"
+    Claims here are limited to the public gRPC proto contract and behavior you can observe from user code — no host-internal narration.
+    External citations are pinned to a specific tag or commit, not a moving branch.
+    Links verified 2026-08-26.
+
+## 1. Where `invocation_id` comes from
+
+Every function execution is driven by the Azure Functions host, which sends the language worker an `InvocationRequest` over gRPC. That message carries a unique per-invocation id:
+
+```proto
+message InvocationRequest {
+  // Unique id for each invocation
+  string invocation_id = 1;
+  ...
+}
+```
+
+— [`FunctionRpc.proto`, `InvocationRequest.invocation_id`](https://github.com/Azure/azure-functions-language-worker-protobuf/blob/v1.14.0-protofile/src/proto/FunctionRpc.proto#L384-L386) (tag `v1.14.0-protofile`). This is the contract: the id is assigned by the host, one per invocation, and delivered to the worker.
+
+## 2. How it reaches your handler
+
+The Python worker surfaces that id to user code through the `func.Context` object it passes to your handler. The public library defines it as an abstract property:
+
+```python
+class Context(abc.ABC):
+    """Function invocation context."""
+
+    @property
+    @abc.abstractmethod
+    def invocation_id(self) -> str:
+        """Function invocation ID."""
+```
+
+— [`Context.invocation_id`](https://github.com/Azure/azure-functions-python-library/blob/2.2.0/azure/functions/_abc.py#L97-L104) (tag `2.2.0`). So `context.invocation_id` inside your handler **is** the id from §1. This library reads it with `getattr(context, "invocation_id")` — nothing more exotic. That is the entire bridge from host to log field.
+
+```python
+with logging_context(context):
+    logger.info("processing")  # record now carries context.invocation_id
+```
+
+## 3. Two ways the id lands on a record
+
+Once the id is bound (via `logging_context`, `inject_context`, or `@with_context`), it is stored in a `contextvars.ContextVar` and copied onto each `LogRecord` by one of two mutually exclusive mechanisms:
+
+| Mode | Mechanism | When to use |
+| --- | --- | --- |
+| Default | `ContextFilter` attached to existing handlers | Standard setup; handlers known at `setup_logging()` time |
+| `use_record_factory=True` | Global `LogRecordFactory` injects at record creation | Handlers added *after* setup, or loggers that bypass the filter chain |
+
+Both read the same bound context and produce the same `invocation_id` on the record — they differ only in *where* in the logging pipeline the injection happens. They are never combined (see [Architecture](architecture.md)).
+
+## 4. Why background threads lose the id
+
+`contextvars` are bound to the running thread. Python does **not** automatically copy the current context into a new `threading.Thread` or a `ThreadPoolExecutor` worker — see the [CPython `contextvars` documentation](https://docs.python.org/3.12/library/contextvars.html). So a record emitted from a thread you spawned inside the handler will have **no** `invocation_id`, even though the parent invocation had one.
+
+The fix is explicit propagation:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+from azure_functions_logging import logging_context, propagate_context
+
+with logging_context(context):
+    with ThreadPoolExecutor() as pool:
+        pool.submit(propagate_context(do_work, context=context), payload)
+```
+
+`propagate_context()` binds the current invocation context to the callable so it stays correlated on the worker thread. This is opt-in and correlation-only; the library never monkeypatches `threading` / `concurrent.futures`. See [Troubleshooting: background-thread logs lose `invocation_id`](troubleshooting.md#background-thread-logs-lose-invocation_id).
+
+## 5. Relationship to Application Insights `operation_Id`
+
+`invocation_id` is **this library's** field: a stable key you control, present on every record, ideal for `where invocation_id == "..."` queries. Application Insights has its own distributed-correlation model built on the W3C [Trace Context](https://www.w3.org/TR/2021/REC-trace-context-1-20211123/) recommendation, where telemetry is stitched together by `operation_Id` / `operation_ParentId` — see [Azure Monitor telemetry correlation](https://learn.microsoft.com/en-us/azure/azure-monitor/app/distributed-trace-data).
+
+These are **complementary, not equal**:
+
+- `invocation_id` — always present, owned by this library, guaranteed one-per-invocation from the proto contract (§1).
+- `operation_Id` — owned by the host/ingestion pipeline and the W3C trace context; this library does not set or guarantee it.
+
+To also correlate at the trace level, opt into `activate_trace_context=True` so records inherit the invocation's `trace_id` / `span_id` — but that is trace correlation, not the `invocation_id` field described here. If a record has an `invocation_id` but a mismatched or missing `operation_Id`, that is expected: the two identifiers come from different owners.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,6 +12,7 @@ Part of the **Azure Functions Python DX Toolkit**. Drop-in structured (JSON) log
 ## User Guide
 - [Usage](https://yeongseon.dev/azure-functions-python/logging/usage/): Helper reference and injection modes.
 - [Architecture](https://yeongseon.dev/azure-functions-python/logging/architecture/): How the logging pipeline works.
+- [How Correlation Works](https://yeongseon.dev/azure-functions-python/logging/how-correlation-works/): How `invocation_id` flows from the host to every log record, and how it relates to Application Insights correlation.
 
 ## Examples
 - [Basic Setup](https://yeongseon.dev/azure-functions-python/logging/examples/basic_setup/): Get started fast.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -324,6 +324,39 @@ additionally imports the **private** `opentelemetry.sdk._logs` path, which remai
 underscore-private upstream and can break on OTel upgrades. This affects tests
 only — it is never imported by shipped runtime code.
 
+## Background-Thread Logs Lose `invocation_id`
+
+### Symptoms
+
+- Records emitted from a `threading.Thread` or `ThreadPoolExecutor` worker have no `invocation_id`, while records on the handler thread do.
+
+### Root Cause
+
+Invocation context is stored in `contextvars`, which do not automatically propagate to threads you spawn inside the handler.
+
+### Resolution
+
+Wrap the callable with `propagate_context()` immediately before submitting the work:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+from azure_functions_logging import logging_context, propagate_context
+
+with logging_context(context):
+    with ThreadPoolExecutor() as pool:
+        pool.submit(propagate_context(do_work, context=context), payload)
+```
+
+See [How correlation works: background threads](how-correlation-works.md#4-why-background-threads-lose-the-id).
+
+## `invocation_id` Does Not Match Application Insights `operation_Id`
+
+### Clarification
+
+`invocation_id` is this library's field — always present, one per invocation, read from the host's gRPC contract. `operation_Id` is owned by the host/ingestion pipeline and the W3C trace context. A record can carry an `invocation_id` while `operation_Id` is absent or different; the two identifiers have different owners and are not guaranteed equal.
+
+See [How correlation works: vs Application Insights](how-correlation-works.md#5-relationship-to-application-insights-operation_id).
+
 ## Fast Diagnostic Checklist
 
 Run through this list during incidents:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -353,7 +353,7 @@ See [How correlation works: background threads](how-correlation-works.md#4-why-b
 
 ### Clarification
 
-`invocation_id` is this library's field — always present, one per invocation, read from the host's gRPC contract. `operation_Id` is owned by the host/ingestion pipeline and the W3C trace context. A record can carry an `invocation_id` while `operation_Id` is absent or different; the two identifiers have different owners and are not guaranteed equal.
+`invocation_id` is this library's field — present on every record emitted within a bound invocation context (`logging_context()` / `inject_context()`), one per invocation, read from the host's gRPC contract. It can be absent outside that context — for example on records from background threads that did not call `propagate_context()`. `operation_Id` is owned by the host/ingestion pipeline and the W3C trace context. A record can carry an `invocation_id` while `operation_Id` is absent or different; the two identifiers have different owners and are not guaranteed equal.
 
 See [How correlation works: vs Application Insights](how-correlation-works.md#5-relationship-to-application-insights-operation_id).
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - Usage: usage.md
       - Architecture: architecture.md
       - OpenTelemetry: opentelemetry.md
+      - How Correlation Works: how-correlation-works.md
   - Examples:
       - Basic Setup: examples/basic_setup.md
       - JSON Output: examples/json_output.md

--- a/src/azure_functions_logging/_context.py
+++ b/src/azure_functions_logging/_context.py
@@ -322,6 +322,10 @@ def propagate_context(
         A wrapper around *func* that applies the snapshotted context on entry and
         restores the previous state on exit. Reusable and concurrency-safe: it may
         be submitted to multiple threads simultaneously.
+
+    See Also:
+        How correlation works, background threads:
+        https://yeongseon.dev/azure-functions-python/logging/how-correlation-works/#4-why-background-threads-lose-the-id
     """
     snapshot: tuple[tuple[contextvars.ContextVar[Any], Any], ...] = tuple(
         (var, var.get()) for var in _PROPAGATED_CONTEXT_VARS

--- a/src/azure_functions_logging/_decorator.py
+++ b/src/azure_functions_logging/_decorator.py
@@ -331,6 +331,10 @@ def with_context(
 
     Both sync and async handlers are supported.
 
+    See Also:
+        How correlation works, how the id reaches your handler:
+        https://yeongseon.dev/azure-functions-python/logging/how-correlation-works/#2-how-it-reaches-your-handler
+
     Args:
         func: The handler function (when used without parentheses).
         param: Name of the parameter that receives the Azure Functions

--- a/src/azure_functions_logging/_setup.py
+++ b/src/azure_functions_logging/_setup.py
@@ -144,6 +144,8 @@ def setup_logging(
             handlers, because the global ``LogRecordFactory`` would be
             overwritten by the filter at handler dispatch time. Defaults to
             False to preserve the existing handler-filter-only behavior.
+            See how correlation works, injection modes:
+            https://yeongseon.dev/azure-functions-python/logging/how-correlation-works/#3-two-ways-the-id-lands-on-a-record
         extra_context_vars: Optional mapping of ``field_name -> ContextVar``
             whose current values are copied onto each LogRecord, alongside the
             built-in context fields. Field names must not collide with the


### PR DESCRIPTION
## Summary
- Adds `docs/how-correlation-works.md` — a single-source mechanism page tracing how `invocation_id` flows from the host's gRPC `InvocationRequest` → `func.Context` → every log record, covering the two mutually-exclusive injection modes (`ContextFilter` vs `LogRecordFactory`), why `contextvars` don't cross threads (`propagate_context`), and how `invocation_id` relates to Application Insights `operation_Id`.
- All external citations are tag/commit-pinned permalinks (proto `v1.14.0-protofile`, python-library `2.2.0`, CPython 3.12 contextvars, W3C Trace Context REC, Azure Monitor correlation) — 5 links, all ≤6, verified 2026-08-26.
- Wires the page into mkdocs nav (User Guide), `docs/llms.txt`, and a one-line README link.

## #408 (folded in — cross-linking)
- Authors the previously-missing symptom anchors: **background-thread loses `invocation_id`** and **`invocation_id` vs `operation_Id` mismatch** — in both README "Common symptoms → fixes" and `docs/troubleshooting.md`.
- Adds `See Also` doc-URL references to the `propagate_context`, `with_context`, and `use_record_factory` docstrings.

## Verification
- `hatch run mkdocs build --strict` passes (nav + all internal links resolve).
- Claims limited to the public proto contract and observable behavior — no host-internal narration.

Closes #405
Closes #408