### PR TITLE
ci(docs): add external-link tag-integrity check

### DIFF
--- a/.github/workflows/doc-link-integrity.yml
+++ b/.github/workflows/doc-link-integrity.yml
@@ -1,0 +1,41 @@
+name: Doc Link Tag-Integrity
+
+# Guards against documentation citing external source at a moving ref
+# (e.g. /blob/main/...). Runs the static check on docs-touching PRs, and a
+# weekly network-verified pass that also fails on refs that 404 upstream.
+# See tools/lint_doc_links.py.
+
+on:
+  pull_request:
+    paths:
+      - "README*.md"
+      - "DESIGN.md"
+      - "docs/**/*.md"
+      - "tools/lint_doc_links.py"
+      - ".github/workflows/doc-link-integrity.yml"
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  link-integrity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Check external links are immutably pinned
+        run: python tools/lint_doc_links.py
+
+      - name: Verify external link refs exist (scheduled / manual)
+        if: github.event_name != 'pull_request'
+        run: python tools/lint_doc_links.py --verify-refs

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,14 @@ lint-workflows: ensure-hatch
 	@$(HATCH) run python tools/lint_release_workflows.py
 	@$(HATCH) run python tools/lint_workflow_pins.py
 
+.PHONY: lint-doc-links
+lint-doc-links: ensure-hatch
+	@$(HATCH) run python tools/lint_doc_links.py
+
 .PHONY: check-all
 check-all: ensure-hatch
 	@$(MAKE) lint-workflows
+	@$(MAKE) lint-doc-links
 	@$(MAKE) check
 	@$(MAKE) test
 	@$(MAKE) security

--- a/tests/test_doc_link_tag_integrity.py
+++ b/tests/test_doc_link_tag_integrity.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _LINT_PATH = _REPO_ROOT / "tools" / "lint_doc_links.py"
 
@@ -60,3 +62,66 @@ def test_external_raw_main_fails() -> None:
     text = "https://raw.githubusercontent.com/Azure/lib/main/azure/functions/_abc.py\n"
     errors = lint_mod.check_links(text, "fake.md")
     assert errors and "mutable ref 'main'" in errors[0]
+
+
+class _FakeResp:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    def __enter__(self) -> "_FakeResp":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def test_verify_refs_checks_full_url_and_passes_on_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--verify-refs must HEAD the full citation URL (ref + path), not a truncated one."""
+    lint_mod._ref_exists.cache_clear()
+    seen: list[str] = []
+
+    def fake_urlopen(req, timeout=10.0):  # type: ignore[no-untyped-def]
+        seen.append(req.full_url)
+        return _FakeResp(200)
+
+    monkeypatch.setattr(lint_mod, "urlopen", fake_urlopen)
+    url = "https://github.com/Azure/proto/blob/v1.0.0/src/proto/FunctionRpc.proto"
+    text = f"See [proto]({url}#L10).\n"
+    errors = lint_mod.check_links(text, "fake.md", verify_refs=True)
+    assert errors == []
+    # The full path (ref + file path) is verified, not just up through the ref.
+    assert seen == [url]
+
+
+def test_verify_refs_fails_on_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A definitive 404 on the full citation URL must be reported as drift."""
+    lint_mod._ref_exists.cache_clear()
+    seen: list[str] = []
+
+    def fake_urlopen(req, timeout=10.0):  # type: ignore[no-untyped-def]
+        seen.append(req.full_url)
+        raise lint_mod.HTTPError(req.full_url, 404, "Not Found", hdrs=None, fp=None)
+
+    monkeypatch.setattr(lint_mod, "urlopen", fake_urlopen)
+    url = "https://raw.githubusercontent.com/Azure/lib/2.2.0/azure/functions/_missing.py"
+    text = f"{url}\n"
+    errors = lint_mod.check_links(text, "fake.md", verify_refs=True)
+    assert errors and "does not" in errors[0] and url in errors[0]
+    assert seen == [url]
+
+
+def test_verify_refs_caches_per_unique_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeated occurrences of the same URL trigger a single network call."""
+    lint_mod._ref_exists.cache_clear()
+    calls: list[str] = []
+
+    def fake_urlopen(req, timeout=10.0):  # type: ignore[no-untyped-def]
+        calls.append(req.full_url)
+        return _FakeResp(200)
+
+    monkeypatch.setattr(lint_mod, "urlopen", fake_urlopen)
+    url = "https://github.com/Azure/proto/blob/v1.0.0/a.proto"
+    text = f"{url}\n{url}\n{url}\n"
+    errors = lint_mod.check_links(text, "fake.md", verify_refs=True)
+    assert errors == []
+    assert calls == [url]

--- a/tests/test_doc_link_tag_integrity.py
+++ b/tests/test_doc_link_tag_integrity.py
@@ -1,0 +1,62 @@
+"""Regression guard for the documentation external-link tag-integrity lint.
+
+Exercises tools/lint_doc_links.py against this repo (must be clean) and against
+synthetic drift (must be caught). Keeps the vendored lint honest.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LINT_PATH = _REPO_ROOT / "tools" / "lint_doc_links.py"
+
+_spec = importlib.util.spec_from_file_location("lint_doc_links", _LINT_PATH)
+assert _spec and _spec.loader
+lint_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint_mod)
+
+
+def test_repo_docs_are_link_clean() -> None:
+    """Every committed doc must cite external source at an immutable ref."""
+    assert lint_mod.lint() == []
+
+
+def test_sha_blob_link_passes() -> None:
+    sha = "a" * 40
+    text = f"See [proto](https://github.com/Azure/proto/blob/{sha}/x.proto#L1).\n"
+    assert lint_mod.check_links(text, "fake.md") == []
+
+
+def test_tag_blob_link_passes() -> None:
+    text = "See [ctx](https://github.com/Azure/lib/blob/v1.14.0-protofile/a.py#L2).\n"
+    assert lint_mod.check_links(text, "fake.md") == []
+
+
+def test_raw_tag_link_passes() -> None:
+    text = "https://raw.githubusercontent.com/Azure/lib/2.2.0/azure/functions/_abc.py\n"
+    assert lint_mod.check_links(text, "fake.md") == []
+
+
+def test_self_owner_main_link_is_skipped() -> None:
+    text = "https://github.com/yeongseon/azure-functions-logging-python/blob/main/README.md\n"
+    assert lint_mod.check_links(text, "fake.md") == []
+
+
+def test_external_main_blob_fails() -> None:
+    text = "https://github.com/Azure/proto/blob/main/src/proto/FunctionRpc.proto\n"
+    errors = lint_mod.check_links(text, "fake.md")
+    assert errors and "mutable ref 'main'" in errors[0]
+
+
+def test_external_master_tree_fails() -> None:
+    text = "https://github.com/Azure/lib/tree/master/azure\n"
+    errors = lint_mod.check_links(text, "fake.md")
+    assert errors and "mutable ref 'master'" in errors[0]
+
+
+def test_external_raw_main_fails() -> None:
+    text = "https://raw.githubusercontent.com/Azure/lib/main/azure/functions/_abc.py\n"
+    errors = lint_mod.check_links(text, "fake.md")
+    assert errors and "mutable ref 'main'" in errors[0]

--- a/tools/lint_doc_links.py
+++ b/tools/lint_doc_links.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""External-link tag-integrity lint for documentation.
+
+Part of the DX Toolkit CI hardening work (sibling to
+``tools/lint_workflow_pins.py``). Where that lint keeps GitHub Actions pinned to
+immutable commit SHAs, this lint keeps **documentation citations** pinned to
+immutable refs.
+
+Motivation -- a docs page that cites external source code with a
+``/blob/main/...`` link is citing a *moving target*: the referenced line can
+shift or disappear on the next upstream commit, silently invalidating the claim
+the docs page makes. Citations must therefore point at an immutable ref (a
+release tag or a 40-hex commit SHA), never a branch.
+
+Rule -- every external GitHub source link (``/blob/``, ``/tree/``, ``/raw/`` on
+``github.com``, or any ``raw.githubusercontent.com`` link) MUST resolve to an
+immutable ref:
+
+1. A full 40-hex commit SHA; or
+2. A ref that is not a known mutable branch name (treated as a tag).
+
+Links to the project's own repositories (owners in ``SELF_OWNERS``) are skipped:
+they intentionally track the living repo and are not third-party citations.
+
+With ``--verify-refs`` the lint additionally makes a network request per unique
+link and fails on a definitive ``404`` (a tag/SHA/path that does not exist).
+Transient network errors are reported as warnings and never fail the run, so the
+scheduled job does not flake on rate limits or offline runners.
+
+Stdlib-only on purpose: the lint must not itself depend on a package that can
+drift. Exit code 0 = clean, 1 = drift detected.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+# Files whose external citations must be immutable.
+DOC_GLOBS = ("README*.md", "DESIGN.md", "docs/**/*.md")
+
+# Owners whose links track the living project repo, not third-party citations.
+SELF_OWNERS = {"yeongseon"}
+
+# Refs that move over time; citing them defeats the point of a permalink.
+MUTABLE_REFS = {
+    "main",
+    "master",
+    "head",
+    "dev",
+    "develop",
+    "trunk",
+    "latest",
+    "next",
+    "stable",
+    "gh-pages",
+}
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# github.com/<owner>/<repo>/(blob|tree|raw)/<ref>/<path...>
+_GH_BLOB_RE = re.compile(
+    r"https://github\.com/"
+    r"(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/"
+    r"(?:blob|tree|raw)/"
+    r"(?P<ref>[^/\s#)]+)"
+)
+# raw.githubusercontent.com/<owner>/<repo>/<ref>/<path...>
+_GH_RAW_RE = re.compile(
+    r"https://raw\.githubusercontent\.com/"
+    r"(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/"
+    r"(?P<ref>[^/\s#)]+)"
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _iter_doc_files(root: Path) -> list[Path]:
+    seen: set[Path] = set()
+    files: list[Path] = []
+    for pattern in DOC_GLOBS:
+        for path in sorted(root.glob(pattern)):
+            if path.is_file() and path not in seen:
+                seen.add(path)
+                files.append(path)
+    return files
+
+
+def _ref_exists(url: str, *, timeout: float = 10.0) -> tuple[bool | None, str]:
+    """Return (exists, note). ``None`` means indeterminate (transient error)."""
+    req = Request(url, method="HEAD", headers={"User-Agent": "doc-link-lint"})
+    try:
+        with urlopen(req, timeout=timeout) as resp:  # noqa: S310 - fixed https host
+            return (200 <= resp.status < 400, f"HTTP {resp.status}")
+    except HTTPError as exc:
+        if exc.code == 404:
+            return (False, "HTTP 404")
+        # 403/429/5xx: rate-limited or transient, do not fail the build.
+        return (None, f"HTTP {exc.code}")
+    except (URLError, TimeoutError, OSError) as exc:  # pragma: no cover - network
+        return (None, f"network error: {exc}")
+
+
+def check_links(text: str, rel_path: str, *, verify_refs: bool = False) -> list[str]:
+    """Assert every external GitHub source link points at an immutable ref."""
+    errors: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for pattern in (_GH_BLOB_RE, _GH_RAW_RE):
+            for m in pattern.finditer(line):
+                owner = m.group("owner")
+                if owner in SELF_OWNERS:
+                    continue
+                ref = m.group("ref")
+                if _SHA_RE.match(ref):
+                    pass
+                elif ref.lower() in MUTABLE_REFS:
+                    errors.append(
+                        f"{rel_path}:{lineno}: external link pinned to mutable "
+                        f"ref '{ref}' ({owner}/{m.group('repo')}); cite a release "
+                        f"tag or 40-hex commit SHA instead of a branch"
+                    )
+                    continue
+                if verify_refs:
+                    exists, note = _ref_exists(m.group(0))
+                    if exists is False:
+                        errors.append(
+                            f"{rel_path}:{lineno}: external link ref does not "
+                            f"exist ({note}): {m.group(0)}"
+                        )
+                    elif exists is None:
+                        print(
+                            f"  ~ {rel_path}:{lineno}: could not verify "
+                            f"{m.group(0)} ({note}); skipping",
+                            file=sys.stderr,
+                        )
+    return errors
+
+
+def lint(root: Path | None = None, *, verify_refs: bool = False) -> list[str]:
+    """Run tag-integrity over every doc file; return human-readable violations."""
+    root = root or _repo_root()
+    errors: list[str] = []
+    for path in _iter_doc_files(root):
+        rel = path.relative_to(root).as_posix()
+        errors.extend(check_links(path.read_text(encoding="utf-8"), rel, verify_refs=verify_refs))
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--verify-refs",
+        action="store_true",
+        help="Also make a network request per link and fail on a definitive 404.",
+    )
+    args = parser.parse_args(argv)
+
+    errors = lint(verify_refs=args.verify_refs)
+    if errors:
+        print("Documentation external-link tag-integrity drift detected:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print("Documentation links: every external GitHub citation is immutably pinned.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/lint_doc_links.py
+++ b/tools/lint_doc_links.py
@@ -34,6 +34,7 @@ drift. Exit code 0 = clean, 1 = drift detected.
 from __future__ import annotations
 
 import argparse
+import functools
 from pathlib import Path
 import re
 import sys
@@ -68,12 +69,14 @@ _GH_BLOB_RE = re.compile(
     r"(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/"
     r"(?:blob|tree|raw)/"
     r"(?P<ref>[^/\s#)]+)"
+    r"(?P<path>(?:/[^\s#)]*)?)"
 )
 # raw.githubusercontent.com/<owner>/<repo>/<ref>/<path...>
 _GH_RAW_RE = re.compile(
     r"https://raw\.githubusercontent\.com/"
     r"(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/"
     r"(?P<ref>[^/\s#)]+)"
+    r"(?P<path>(?:/[^\s#)]*)?)"
 )
 
 
@@ -92,6 +95,7 @@ def _iter_doc_files(root: Path) -> list[Path]:
     return files
 
 
+@functools.lru_cache(maxsize=None)
 def _ref_exists(url: str, *, timeout: float = 10.0) -> tuple[bool | None, str]:
     """Return (exists, note). ``None`` means indeterminate (transient error)."""
     req = Request(url, method="HEAD", headers={"User-Agent": "doc-link-lint"})


### PR DESCRIPTION
## Summary
- Adds `tools/lint_doc_links.py` — a stdlib-only lint (sibling to `lint_workflow_pins.py`) that fails when documentation cites external GitHub source at a **mutable ref** (`/blob/main/…`, `master`, `HEAD`, `dev`, etc.). Citations must resolve to an immutable ref (release tag or 40-hex commit SHA) so a doc claim can't be silently invalidated by an upstream commit.
- Links to the project's own repos (`SELF_OWNERS`) are skipped — they intentionally track the living repo.
- `--verify-refs` makes a network request per link and fails on a definitive `404`; transient errors (rate-limit/offline) are warnings, never failures.

## Wiring
- New **Doc Link Tag-Integrity** workflow: static check on docs-touching PRs; weekly scheduled + `workflow_dispatch` pass adds `--verify-refs`.
- Makefile `lint-doc-links` target, included in `check-all`.
- Regression tests in `tests/test_doc_link_tag_integrity.py` (repo-clean assertion + synthetic drift cases).

## Verification
- `python tools/lint_doc_links.py` → clean on current docs.
- `pytest tests/test_doc_link_tag_integrity.py` → 8 passing.

Closes #407