### PR TITLE
test(e2e): assert correlation-doc claims in host-boot matrix smoke

### DIFF
--- a/.github/workflows/e2e-host-matrix.yml
+++ b/.github/workflows/e2e-host-matrix.yml
@@ -113,6 +113,31 @@ jobs:
           echo "version response: $VERSION"
           echo "$VERSION" | grep -q '"version"'
 
+          echo "Exercising /api/correlation to certify correlation claims..."
+          CORR="$(curl -fsS http://127.0.0.1:7071/api/correlation)"
+          echo "correlation response: $CORR"
+
+          # Worker log records reach the host log asynchronously; wait until all
+          # three markers have flushed (or fail loudly with the captured log).
+          markers=""
+          for i in $(seq 1 24); do
+            if grep -q 'corr-main-1' "$RUNNER_TEMP/func-host.log" \
+               && grep -q 'corr-main-2' "$RUNNER_TEMP/func-host.log" \
+               && grep -q 'corr-thread-unpropagated' "$RUNNER_TEMP/func-host.log"; then
+              markers="yes"
+              break
+            fi
+            sleep 5
+          done
+          if [ -z "$markers" ]; then
+            echo "::error ::correlation markers never appeared in the host log (Core Tools ${{ matrix.core_tools }})"
+            cat "$RUNNER_TEMP/func-host.log" || true
+            exit 1
+          fi
+
+          echo "Asserting correlation claims against the host log..."
+          python ../../scripts/assert_correlation.py "$RUNNER_TEMP/func-host.log"
+
       - name: Stop background processes
         if: always()
         run: |

--- a/examples/e2e_app/function_app.py
+++ b/examples/e2e_app/function_app.py
@@ -181,4 +181,3 @@ def correlation(req: func.HttpRequest, context: func.Context) -> func.HttpRespon
         )
     finally:
         afl.restore_context(tokens)
-        afl.restore_context(tokens)

--- a/examples/e2e_app/function_app.py
+++ b/examples/e2e_app/function_app.py
@@ -1,11 +1,15 @@
 """E2E test function app for azure-functions-logging.
 
-Exposes four endpoints:
+Exposes these endpoints:
 
 - GET /api/health            — liveness probe
 - GET /api/before            — BEFORE: plain stdlib logging, no context injection
 - GET /api/after             — AFTER:  azure-functions-logging with full context
 - GET /api/logme             — alias for /api/after (e2e test compat)
+- GET /api/correlation       — emits records that certify correlation claims:
+                               two main-thread records share one invocation_id,
+                               and a background thread without propagate_context
+                               loses it (negative control).
 """
 
 from __future__ import annotations
@@ -13,6 +17,7 @@ from __future__ import annotations
 import importlib.metadata
 import json
 import logging
+import threading
 
 import azure.functions as func
 
@@ -131,4 +136,49 @@ def logme(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
             mimetype="application/json",
         )
     finally:
+        afl.restore_context(tokens)
+
+
+# ── correlation certification ────────────────────────────────────────────
+#
+# Emits records that let the host-boot matrix smoke assert the claims made in
+# docs/how-correlation-works.md against a real func host:
+#
+#   1. invocation_id on a bound record parses as a UUID (§1–§2).
+#   2. Two records from the same invocation share one invocation_id (§2).
+#   3. A background thread WITHOUT propagate_context loses the invocation_id
+#      (§4, negative control) — proving the contextvars boundary is real.
+#
+# Every record carries a stable "marker" extra field so the assertion script can
+# locate the exact lines regardless of ordering or interleaving.
+
+
+@app.route(route="correlation", auth_level=func.AuthLevel.ANONYMOUS)
+def correlation(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
+    """Emit correlation-certification records for the host-boot smoke."""
+    logger = afl.get_logger(__name__)
+    tokens = afl.inject_context(context)
+    try:
+        # (1) + (2): two bound records on the request thread — same invocation_id,
+        # which must be a valid UUID.
+        logger.info("afl correlation certify", extra={"marker": "corr-main-1"})
+        logger.info("afl correlation certify", extra={"marker": "corr-main-2"})
+
+        # (3) negative control: a background thread with NO propagate_context.
+        # Its record must NOT carry the invocation_id.
+        def _unpropagated() -> None:
+            logger.warning(
+                "afl correlation certify", extra={"marker": "corr-thread-unpropagated"}
+            )
+
+        thread = threading.Thread(target=_unpropagated)
+        thread.start()
+        thread.join()
+
+        return func.HttpResponse(
+            json.dumps({"endpoint": "correlation", "invocation_id": context.invocation_id}),
+            mimetype="application/json",
+        )
+    finally:
+        afl.restore_context(tokens)
         afl.restore_context(tokens)

--- a/scripts/assert_correlation.py
+++ b/scripts/assert_correlation.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Assert the correlation claims from docs/how-correlation-works.md against a log.
+"""Assert the correlation claims from the public "How correlation works" docs against a log.
 
 Consumes the ``func`` host log produced by the host-boot matrix smoke after a
 request to ``/api/correlation`` (see ``examples/e2e_app/function_app.py``) and
-certifies three observable claims:
+certifies three observable claims (documented at
+``https://yeongseon.dev/azure-functions-python/logging/how-correlation-works/``):
 
 1. ``invocation_id`` on a bound record parses as a UUID (proto contract, §1–§2).
 2. Two records from the same invocation share one ``invocation_id`` (§2).
@@ -37,8 +38,8 @@ def _extract_json_objects(text: str) -> list[dict[str, object]]:
     """Return every top-level JSON object embedded anywhere in *text*.
 
     The host prefixes worker log lines with its own text, so a record may not
-    start at column 0. Scan for balanced ``{...}`` spans and keep the ones that
-    parse as objects carrying our ``marker`` field.
+    start at column 0. Scan for balanced ``{...}`` spans and keep every span that
+    parses as a JSON object; callers filter by ``marker`` via :func:`_find`.
     """
     objects: list[dict[str, object]] = []
     depth = 0
@@ -145,7 +146,8 @@ def main(argv: list[str]) -> int:
     if len(argv) != 2:
         print(f"usage: {argv[0]} <path-to-func-host.log>", file=sys.stderr)
         return 2
-    text = open(argv[1], encoding="utf-8", errors="replace").read()
+    with open(argv[1], encoding="utf-8", errors="replace") as fh:
+        text = fh.read()
     failures = check(text)
     if failures:
         print("Correlation certification FAILED:", file=sys.stderr)

--- a/scripts/assert_correlation.py
+++ b/scripts/assert_correlation.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Assert the correlation claims from docs/how-correlation-works.md against a log.
+
+Consumes the ``func`` host log produced by the host-boot matrix smoke after a
+request to ``/api/correlation`` (see ``examples/e2e_app/function_app.py``) and
+certifies three observable claims:
+
+1. ``invocation_id`` on a bound record parses as a UUID (proto contract, §1–§2).
+2. Two records from the same invocation share one ``invocation_id`` (§2).
+3. A background thread *without* ``propagate_context`` loses the ``invocation_id``
+   (§4, negative control) — proving the ``contextvars`` boundary is real.
+
+The document is not the deliverable here; the *assertion* is. If any claim the
+docs make stops being true on a real host, this script fails the smoke.
+
+Usage:
+    python scripts/assert_correlation.py <path-to-func-host.log>
+
+Stdlib-only on purpose. Exit code 0 = all claims hold, 1 = a claim failed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from uuid import UUID
+
+DOC_URL = "https://yeongseon.dev/azure-functions-python/logging/how-correlation-works/"
+
+# Markers emitted by the /api/correlation endpoint.
+MAIN_1 = "corr-main-1"
+MAIN_2 = "corr-main-2"
+THREAD = "corr-thread-unpropagated"
+
+
+def _extract_json_objects(text: str) -> list[dict[str, object]]:
+    """Return every top-level JSON object embedded anywhere in *text*.
+
+    The host prefixes worker log lines with its own text, so a record may not
+    start at column 0. Scan for balanced ``{...}`` spans and keep the ones that
+    parse as objects carrying our ``marker`` field.
+    """
+    objects: list[dict[str, object]] = []
+    depth = 0
+    start = -1
+    in_str = False
+    escape = False
+    for i, ch in enumerate(text):
+        if in_str:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            if depth > 0:
+                depth -= 1
+                if depth == 0 and start >= 0:
+                    chunk = text[start : i + 1]
+                    try:
+                        obj = json.loads(chunk)
+                    except json.JSONDecodeError:
+                        pass
+                    else:
+                        if isinstance(obj, dict):
+                            objects.append(obj)
+                    start = -1
+    return objects
+
+
+def _marker(record: dict[str, object]) -> str | None:
+    extra = record.get("extra")
+    if isinstance(extra, dict):
+        marker = extra.get("marker")
+        if isinstance(marker, str):
+            return marker
+    marker = record.get("marker")
+    return marker if isinstance(marker, str) else None
+
+
+def _find(records: list[dict[str, object]], marker: str) -> dict[str, object] | None:
+    for record in records:
+        if _marker(record) == marker:
+            return record
+    return None
+
+
+def check(text: str) -> list[str]:
+    """Return a list of failure messages (empty == all claims hold)."""
+    records = _extract_json_objects(text)
+    failures: list[str] = []
+
+    main_1 = _find(records, MAIN_1)
+    main_2 = _find(records, MAIN_2)
+    thread = _find(records, THREAD)
+
+    if main_1 is None:
+        failures.append(f"no record found with marker '{MAIN_1}'")
+    if main_2 is None:
+        failures.append(f"no record found with marker '{MAIN_2}'")
+    if thread is None:
+        failures.append(f"no record found with marker '{THREAD}'")
+    if failures:
+        return failures
+
+    assert main_1 is not None and main_2 is not None and thread is not None
+
+    # Claim 1: invocation_id parses as a UUID.
+    inv_1 = main_1.get("invocation_id")
+    if not isinstance(inv_1, str):
+        failures.append(f"'{MAIN_1}' has no string invocation_id: {inv_1!r}")
+    else:
+        try:
+            UUID(inv_1)
+        except ValueError:
+            failures.append(f"'{MAIN_1}' invocation_id is not a UUID: {inv_1!r}")
+
+    # Claim 2: both main-thread records share the same invocation_id.
+    inv_2 = main_2.get("invocation_id")
+    if inv_1 != inv_2:
+        failures.append(
+            f"invocation_id differs within one invocation: {MAIN_1}={inv_1!r} vs {MAIN_2}={inv_2!r}"
+        )
+
+    # Claim 3: the unpropagated background-thread record has no invocation_id.
+    inv_thread = thread.get("invocation_id")
+    if inv_thread not in (None, ""):
+        failures.append(
+            f"'{THREAD}' unexpectedly carried an invocation_id ({inv_thread!r}); "
+            f"a background thread without propagate_context must lose it"
+        )
+
+    return failures
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <path-to-func-host.log>", file=sys.stderr)
+        return 2
+    text = open(argv[1], encoding="utf-8", errors="replace").read()
+    failures = check(text)
+    if failures:
+        print("Correlation certification FAILED:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        print(f"\nSee {DOC_URL} for the claims under test.", file=sys.stderr)
+        return 1
+    print("Correlation certification passed: all three claims hold.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
The deliverable here is the **assertion**, not the doc. This turns the claims in `docs/how-correlation-works.md` into an executable check that fails the host-boot smoke if any of them regresses on a real `func` host.

- Adds `/api/correlation` to the e2e app: emits two bound records on the request thread (`corr-main-1`, `corr-main-2`) plus one from a background `threading.Thread` started **without** `propagate_context` (`corr-thread-unpropagated`, the negative control).
- Adds `scripts/assert_correlation.py` (stdlib-only) that parses the host log and certifies three claims:
  1. `invocation_id` on a bound record parses as a UUID
  2. two records from one invocation share the same `invocation_id`
  3. the unpropagated background-thread record loses the `invocation_id`
- Wires both into `e2e-host-matrix.yml`: waits for all three markers to flush to the host log, then runs the script; a failing claim fails the smoke. Failure output links to the correlation page.

## Verification
- `py_compile` clean on the app + script; workflow YAML parses.
- Script self-tested against synthetic host logs: passes on the correct shape, fails (with a clear message) when the background-thread record wrongly carries an `invocation_id`.

Closes #406