### PR TITLE
docs+test: 0.11.0 follow-ups (#425, #426, #427)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,16 @@ These are hard API-surface limits, not soft preferences — changing them requir
 
 Signature of record: `src/azure_functions_logging/_setup.py`.
 
+### `with_context` parameter ceiling
+
+`with_context(...)` today exposes **5 keyword-only parameters** (`param`, `activate_trace_context`, `strict`, `lifecycle`, `lifecycle_level`).
+
+- **No 6th keyword argument.** Future lifecycle extensions (e.g. sampling, a slow-invocation threshold) must arrive via a **config object / preset** — for example a single `lifecycle=LifecycleConfig(...)` object bundling related settings — **not** as new standalone `lifecycle_*` flags.
+- The same reasoning as `setup_logging` applies: each added flag multiplies the valid-combination surface and pushes the decorator toward an untestable configuration matrix.
+- If a new behavior seems to need a kwarg, first ask whether it belongs in a preset, in an existing parameter, or in a separate decorator.
+
+Signature of record: `src/azure_functions_logging/_decorator.py`.
+
 ## Commit Message Guidelines
 
 We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.

--- a/docs/how-correlation-works.md
+++ b/docs/how-correlation-works.md
@@ -70,6 +70,38 @@ with logging_context(context):
 
 `propagate_context()` binds the current invocation context to the callable so it stays correlated on the worker thread. This is opt-in and correlation-only; the library never monkeypatches `threading` / `concurrent.futures`. See [Troubleshooting: background-thread logs lose `invocation_id`](troubleshooting.md#background-thread-logs-lose-invocation_id).
 
+### Anti-patterns
+
+`propagate_context()` snapshots the invocation context **at the moment you call it**, so *when* and *where* you wrap matters:
+
+1. **Do not build a wrapper once and reuse it across invocations.** The wrapper snapshots the invocation context at wrap time and re-applies that *same* snapshot on every call. Wrap once and reuse, and every later invocation's worker-thread records inherit the *first* invocation's `invocation_id`.
+
+    ```python
+    # WRONG: wrapped once, reused — freezes the first invocation's snapshot
+    _worker = None
+
+    def handler(req, context):
+        global _worker
+        with logging_context(context):
+            if _worker is None:
+                _worker = propagate_context(do_work, context=context)
+            pool.submit(_worker, payload)  # carries the FIRST invocation's id forever
+    ```
+
+    Re-wrap **inside** each invocation, immediately before submitting the work, so every submission captures that invocation's live context.
+
+2. **Do not wrap outside an active invocation context.** The wrapper snapshots the `contextvars` fields *as they are when you call `propagate_context()`*. Call it before `logging_context()` binds them (or after it has exited) and the snapshot is empty — the worker thread's records carry a blank `invocation_id` instead of inheriting the invocation's.
+
+    ```python
+    # WRONG: wrapped before the context is bound — captures an empty snapshot
+    wrapped = propagate_context(do_work)
+    with logging_context(context):
+        pool.submit(wrapped, payload)  # records emit an empty invocation_id
+    ```
+
+!!! note "asyncio needs no helper"
+    `contextvars` **are** propagated automatically to `asyncio` tasks (`asyncio.create_task()` copies the current context — see the [CPython `contextvars` docs](https://docs.python.org/3.12/library/contextvars.html)). `propagate_context()` is only for OS threads (`threading.Thread` / `ThreadPoolExecutor`); using it around coroutines or tasks is unnecessary.
+
 ## 5. Relationship to Application Insights `operation_Id`
 
 `invocation_id` is **this library's** field: a stable key you control, present on every record, ideal for `where invocation_id == "..."` queries. Application Insights has its own distributed-correlation model built on the W3C [Trace Context](https://www.w3.org/TR/2021/REC-trace-context-1-20211123/) recommendation, where telemetry is stitched together by `operation_Id` / `operation_ParentId` — see [Azure Monitor telemetry correlation](https://learn.microsoft.com/en-us/azure/azure-monitor/app/distributed-trace-data).

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -15,6 +15,7 @@ Ref: https://github.com/yeongseon/azure-functions-logging/issues/22
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from types import SimpleNamespace
 import warnings
@@ -417,6 +418,23 @@ class TestLifecycleLogging:
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
         @with_context
+        def handler(req: object, context: object) -> str:
+            return "ok"
+
+        with caplog.at_level(logging.DEBUG):
+            assert handler("req", _MOCK_CONTEXT) == "ok"
+
+        events = [r for r in caplog.records if hasattr(r, "lifecycle_event")]
+        assert events == []
+
+    def test_lifecycle_default_off(self, caplog: pytest.LogCaptureFixture) -> None:
+        # Pin the *declared default* so a future refactor cannot silently flip
+        # an output-changing default (#425). Complements the behavioral check
+        # above by asserting the signature default value itself, not just that
+        # the bare-decorator path happens to emit nothing.
+        assert inspect.signature(with_context).parameters["lifecycle"].default is False
+
+        @with_context()
         def handler(req: object, context: object) -> str:
             return "ok"
 


### PR DESCRIPTION
## Summary

0.11.0 documentation/test follow-ups. No runtime behavior changes.

- **#425** — `test(decorator)`: add `test_lifecycle_default_off`, pinning the `with_context(lifecycle=...)` **declared default** via `inspect.signature` (so a refactor can't silently flip an output-changing default) plus a behavioral assertion that the bare/parens-form decorator emits no lifecycle records.
- **#426** — `docs(context)`: document `propagate_context()` wrapping anti-patterns in `how-correlation-works.md` (reuse-frozen-wrapper stale id; wrap-before-bind empty snapshot) and add an asyncio note clarifying `contextvars` propagate to tasks without the helper.
- **#427** — `docs`: declare the `with_context` parameter ceiling (5 kwargs, no 6th) in `CONTRIBUTING.md`'s Design Guardrails, as a sibling to the existing `setup_logging` "no 9th kwarg" ceiling (#397). Future lifecycle options must arrive via a config object / preset, not new flags.

## Verification

- `hatch run pytest -q` → **539 passed, 5 skipped, 97.07% coverage** (gate 95%).
- `make lint-doc-links` clean (external GitHub citations pinned).
- `ruff check` clean on the touched test file.

Closes #425
Closes #426
Closes #427