### PR TITLE
ci(release): scope cross-repo dispatch token to least privilege (#413)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -311,11 +311,16 @@ jobs:
     name: Trigger cookbook e2e re-verification
     needs: [build, publish]
     runs-on: ubuntu-latest
+    # This job never uses GITHUB_TOKEN (the cross-repo dispatch below authenticates
+    # with COOKBOOK_DISPATCH_TOKEN), so drop all GITHUB_TOKEN scopes (#413).
+    permissions: {}
     env:
       # Cross-repo repository_dispatch needs a token with contents:write on the
-      # cookbook repo (GITHUB_TOKEN cannot cross repositories). Supply a PAT or
-      # GitHub App token via the COOKBOOK_DISPATCH_TOKEN secret. When it is unset
-      # the step is skipped, so missing wiring never fails a release.
+      # cookbook repo (GITHUB_TOKEN cannot cross repositories). Prefer a
+      # fine-grained PAT scoped to azure-functions-cookbook-python contents:write
+      # (or a GitHub App installation token) over a broad classic PAT, and rotate
+      # on cutover — supply it via the COOKBOOK_DISPATCH_TOKEN secret. When it is
+      # unset the step is skipped, so missing wiring never fails a release.
       DISPATCH_TOKEN: ${{ secrets.COOKBOOK_DISPATCH_TOKEN }}
     steps:
       - name: Dispatch sibling-release to cookbook


### PR DESCRIPTION
## Summary

Part of the toolkit-wide security audit (umbrella yeongseon/azure-functions-doctor-python#336).

Workflow-side hardening of the `notify-cookbook` job in `publish-pypi.yml`:

- Add `permissions: {}` — the job authenticates the cross-repo `repository_dispatch` with `COOKBOOK_DISPATCH_TOKEN`, never `GITHUB_TOKEN`, so its `GITHUB_TOKEN` needs zero scopes (previously inherited the top-level `contents: read`).
- Document the token requirement as a **fine-grained PAT scoped to `azure-functions-cookbook-python` `contents:write`** (or a GitHub App installation token) over a broad classic PAT, with rotation on cutover.

## Out of scope (requires repo-admin, not automatable from code)

- [ ] Auditing the current `COOKBOOK_DISPATCH_TOKEN` secret scope (secret values/scopes aren't readable from CI).
- [ ] Creating the fine-grained replacement token and updating the repo secret.
- [ ] Rotating the old token after cutover.

These remain tracked on #413 for the maintainer to complete in repo settings.

## Verification

- `make lint-workflows` clean (pins + publish gate canonical, pin-hygiene OK).
- YAML parses.

Refs #413