### PR TITLE
chore: codify open issue-creation as fleet policy (#429)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ What problem this issue addresses and why now. Note the target release (e.g. vX.
 
 When splitting a large piece of work into focused issues, keep the umbrella open as a tracker that links each child issue with a checkbox; close it once every child is closed or explicitly deferred.
 
+### Issue-creation access (fleet policy)
+
+Keep issue creation **open/unrestricted** on every public toolkit repository (issue tracker enabled, no `interaction-limits`). External bug reports are the only inbound support channel, so restricting issue creation suppresses the signal we most need. Do not enable an interaction limit or restrict issue creation without an explicit, documented reason recorded in an issue first.
+
 ## Validation
 - `make test`
 - `make lint`


### PR DESCRIPTION
## Summary

Promotes the F-2 keep/lift decision to the AGENTS.md fleet convention (per #429's scope: this is a fleet policy, not a per-repo call).

- Adds an **"Issue-creation access (fleet policy)"** subsection under Issue Conventions: keep issue creation open/unrestricted on every public toolkit repo; don't add interaction limits without a documented reason.

## Finding (this repo)

Verified via `gh api`: `has_issues: true`, `interaction-limits: {}` → issue creation is **already unrestricted** here. No settings change needed. The "restricted" observation was on the openapi repo. See #429 for the full finding.

Closes #429