### PR TITLE
chore(deps): bump github/codeql-action init+analyze to v4.37.9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:python"


### PR DESCRIPTION
## Summary
- Bumps **both** `github/codeql-action/init` and `github/codeql-action/analyze` from v4.37.7 → **v4.37.9** in a single commit.

## Why one PR instead of two
CodeQL fails the analysis with `Loaded a configuration file for version 'X', but running version 'Y'` when `init` and `analyze` run **different** versions. Dependabot split the bump into two PRs (#415, #416), so each PR alone left `init`/`analyze` mismatched and red. Bumping them together keeps them in lockstep.

Going forward, the dependabot grouping in #392 will bundle these automatically.

Closes #415
Closes #416