### PR TITLE
ci: allow test/ and refactor/ branch prefixes

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -148,6 +148,8 @@ jobs:
               /^dependabot\/.+$/,
               /^feat\/.+$/,
               /^fix\/.+$/,
+              /^refactor\/.+$/,
+              /^test\/.+$/,
               /^docs\/.+$/,
               /^chore\/.+$/,
               /^ci\/.+$/,
@@ -163,6 +165,8 @@ jobs:
                 - dependabot/<ecosystem>/<dependency>
                 - feat/<description>
                 - fix/<description>
+                - refactor/<description>
+                - test/<description>
                 - docs/<description>
                 - chore/<description>
                 - ci/<description>
@@ -188,5 +192,5 @@ jobs:
               owner,
               repo,
               issue_number: prNumber,
-              body: 'Warning: branch naming validation failed\n\nYour branch name `' + branchName + '` does not follow our naming conventions.\n\nPlease rename your branch to follow one of these patterns:\n- `feat/<description>` for new features\n- `fix/<description>` for bug fixes\n- `docs/<description>` for documentation changes\n- `chore/<description>` for maintenance tasks\n- `ci/<description>` for CI/CD changes\n- `codex/<description>` for Codex-generated changes\n\nTo rename your branch:\n1. `git checkout ' + branchName + '`\n2. `git branch -m feat/your-new-branch-name`\n3. `git push origin --delete ' + branchName + '`\n4. `git push origin feat/your-new-branch-name`\n\nOnce you have renamed the branch, please update the PR head branch.'
+              body: 'Warning: branch naming validation failed\n\nYour branch name `' + branchName + '` does not follow our naming conventions.\n\nPlease rename your branch to follow one of these patterns:\n- `feat/<description>` for new features\n- `fix/<description>` for bug fixes\n- `refactor/<description>` for refactoring\n- `test/<description>` for test-only changes\n- `docs/<description>` for documentation changes\n- `chore/<description>` for maintenance tasks\n- `ci/<description>` for CI/CD changes\n- `codex/<description>` for Codex-generated changes\n\nTo rename your branch:\n1. `git checkout ' + branchName + '`\n2. `git branch -m feat/your-new-branch-name`\n3. `git push origin --delete ' + branchName + '`\n4. `git push origin feat/your-new-branch-name`\n\nOnce you have renamed the branch, please update the PR head branch.'
             });


### PR DESCRIPTION
## Context
`branch-naming-validation` (in `.github/workflows/stale.yml`) only permits `feat/`, `fix/`, `docs/`, `chore/`, `ci/`, `codex/`, and `dependabot/` prefixes. However, `AGENTS.md` documents `test` and `refactor` as valid Conventional Commit types. A test-only branch such as `test/otel-contract-tests-437` (PR #438) therefore fails the check despite following documented conventions.

## Change
- Add `refactor/` and `test/` to the `validPatterns` allowlist.
- Update the `core.setFailed` guidance and the PR warning comment body to list the new prefixes.

## Out of scope
- No change to Conventional Commit enforcement or any other governance workflow.

## References
- Unblocks PR #438 (`test/otel-contract-tests-437`).
- `AGENTS.md` → Commit Rules (allowed types: feat, fix, refactor, docs, test, chore, ci).