### PR TITLE
feat(redaction): mask secrets embedded in free-text log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,16 @@ At startup the library warns when your `host.json` — or `AzureFunctionsJobHost
 
 `SamplingFilter` rate-limits chatty third-party loggers (e.g. `azure-core`, `urllib3`); `RedactionFilter` masks sensitive keys (passwords, tokens, secrets, connection strings, and more — case-insensitive, recursive) before logs reach aggregation. Attach either to your root handlers, and pass `sensitive_keys=[...]` to customize redaction.
 
+Key-based redaction can't see a secret embedded in a free-text *message* (e.g. `logger.info("connecting with token=ghp_...")`). Opt into **value/pattern-based** redaction by passing `patterns=`, which masks matches in the rendered message and string `extra` values:
+
+```python
+from azure_functions_logging import DEFAULT_REDACTION_PATTERNS, RedactionFilter
+
+handler.addFilter(RedactionFilter(patterns=DEFAULT_REDACTION_PATTERNS))
+```
+
+`DEFAULT_REDACTION_PATTERNS` is a curated high-confidence set (bearer tokens, `key=value` secrets, Azure connection-string keys / SAS `sig=`, AWS access-key IDs, GitHub tokens, JWTs). It is **off by default** — pattern scanning adds hot-path cost and can produce false positives — so enable it deliberately; you can also supply your own regex strings or compiled patterns. Substitution failures never raise.
+
 → [API: `SamplingFilter`](https://yeongseon.dev/azure-functions-python/logging/api/#samplingfilter) · [API: `RedactionFilter`](https://yeongseon.dev/azure-functions-python/logging/api/#redactionfilter)
 
 ### Context binding
@@ -461,7 +471,7 @@ for handler in logging.getLogger().handlers:
     handler.addFilter(RedactionFilter())  # masks passwords, tokens, secrets, connection strings — recursive, case-insensitive
 ```
 
-**Proves:** matched keys are masked before records leave the process. **Does not prove:** protection for secrets embedded inside free-text messages — redaction is key-based; pass `sensitive_keys=[...]` to extend coverage.
+**Proves:** matched keys are masked before records leave the process. **Does not prove:** protection for secrets embedded inside free-text messages — key-based redaction only sees keys. Opt into `patterns=DEFAULT_REDACTION_PATTERNS` (or your own patterns) for value-based masking of message text, and pass `sensitive_keys=[...]` to extend key coverage.
 
 → [Noise control & PII redaction](#noise-control--pii-redaction)
 </details>

--- a/docs/api.md
+++ b/docs/api.md
@@ -190,6 +190,33 @@ for handler in logging.getLogger().handlers:
 
 ::: azure_functions_logging.RedactionFilter
 
+### Value / pattern-based redaction
+
+By default `RedactionFilter` is **key-based**: it masks values whose *key* is
+sensitive, but not secrets embedded in a free-text message or string `extra`
+(e.g. `logger.info("connecting with token=ghp_...")`). Pass `patterns=` to
+enable **opt-in** value-based redaction of the rendered message and string
+extras:
+
+```python
+from azure_functions_logging import DEFAULT_REDACTION_PATTERNS, RedactionFilter
+
+flt = RedactionFilter(patterns=DEFAULT_REDACTION_PATTERNS)
+```
+
+It is off by default because pattern scanning has a hot-path cost and can
+produce false positives. `DEFAULT_REDACTION_PATTERNS` is a curated set of
+high-confidence secrets (bearer tokens, `key=value` secrets, Azure
+connection-string keys / SAS `sig=`, AWS access-key IDs, GitHub tokens, JWTs);
+patterns with a `keep` named group preserve a readable prefix (e.g. `token=`)
+while masking only the value. You may also pass your own regex strings or
+compiled patterns. Substitution failures never raise (see the design
+principle that redaction failures are silent).
+
+## DEFAULT_REDACTION_PATTERNS
+
+::: azure_functions_logging.DEFAULT_REDACTION_PATTERNS
+
 ## AttributeFlattenFilter
 
 ::: azure_functions_logging.AttributeFlattenFilter

--- a/src/azure_functions_logging/__init__.py
+++ b/src/azure_functions_logging/__init__.py
@@ -14,12 +14,14 @@ from ._decorator import get_logging_metadata, with_context
 from ._filters import AttributeFlattenFilter, RedactionFilter, SamplingFilter
 from ._json_formatter import JsonFormatter
 from ._logger import FunctionLogger
+from ._redaction import DEFAULT_PATTERNS as DEFAULT_REDACTION_PATTERNS
 from ._setup import setup_logging
 
 __all__ = [
     "__version__",
     "AttributeFlattenFilter",
     "ContextTokens",
+    "DEFAULT_REDACTION_PATTERNS",
     "FunctionLogger",
     "get_logger",
     "get_logging_metadata",

--- a/src/azure_functions_logging/_filters.py
+++ b/src/azure_functions_logging/_filters.py
@@ -10,6 +10,7 @@ Provides:
 from __future__ import annotations
 
 import logging
+import re
 import threading
 import time
 from typing import Any, Iterable
@@ -18,6 +19,7 @@ from ._constants import _RESERVED_LOG_RECORD_KEYS
 from ._redaction import MASK as _MASK
 from ._redaction import SENSITIVE_KEYS as _DEFAULT_SENSITIVE_KEYS
 from ._redaction import is_sensitive as _is_sensitive
+from ._redaction import mask_patterns as _mask_patterns
 from ._redaction import normalize_key as _normalize_key
 
 _REDACT_MAX_DEPTH = 10  # default depth limit for recursive redaction
@@ -258,6 +260,17 @@ class RedactionFilter(logging.Filter):
             ``credential``, ``account_key``, ``access_key``.
         name: Optional logger-name scope. When set, only matching loggers are
             subject to redaction; non-matching records pass through unchanged.
+        patterns: Optional iterable of secret patterns (compiled ``re.Pattern``
+            or regex strings) enabling **value-based** redaction of the rendered
+            message and string ``extra`` values — catching secrets embedded in
+            free text that key-based redaction cannot see. Off by default
+            (``None``) to avoid false positives and hot-path scanning cost; pass
+            :data:`~azure_functions_logging._redaction.DEFAULT_PATTERNS` for a
+            curated high-confidence set. A pattern may define a ``keep`` named
+            group to preserve a readable prefix (e.g. ``token=``) while masking
+            only the value. Regex strings are compiled at construction; an
+            invalid pattern raises ``re.error`` there (fail-fast on config), and
+            runtime substitution failures are swallowed (Principle 3).
 
     Note:
         The default set includes ``credential`` which may over-redact
@@ -273,12 +286,18 @@ class RedactionFilter(logging.Filter):
         self,
         sensitive_keys: Iterable[str] | None = None,
         name: str = "",
+        patterns: Iterable[str | re.Pattern[str]] | None = None,
     ) -> None:
         super().__init__(name)
         self._sensitive_keys: frozenset[str] = (
             frozenset(_normalize_key(k) for k in sensitive_keys)
             if sensitive_keys is not None
             else _DEFAULT_SENSITIVE_KEYS
+        )
+        self._patterns: tuple[re.Pattern[str], ...] = (
+            tuple(p if isinstance(p, re.Pattern) else re.compile(p) for p in patterns)
+            if patterns is not None
+            else ()
         )
 
     def filter(self, record: logging.LogRecord) -> bool:
@@ -294,15 +313,35 @@ class RedactionFilter(logging.Filter):
                         continue
                     if _is_sensitive(key, self._sensitive_keys):
                         setattr(record, key, _MASK)
-                    else:
-                        value = record.__dict__[key]
-                        if isinstance(value, (dict, list)):
-                            setattr(record, key, _redact_value(value, self._sensitive_keys))
+                        continue
+                    value = record.__dict__[key]
+                    if isinstance(value, (dict, list)):
+                        setattr(record, key, _redact_value(value, self._sensitive_keys))
+                    elif self._patterns and isinstance(value, str):
+                        setattr(record, key, _mask_patterns(value, self._patterns))
                 except Exception:  # nosec B110 — one broken field must not stop others
                     pass
+            if self._patterns:
+                self._mask_message(record)
         except Exception:  # nosec B110 — filter must never raise
             pass
         return True
+
+    def _mask_message(self, record: logging.LogRecord) -> None:
+        """Mask secrets embedded in the rendered message via ``self._patterns``.
+
+        Renders the message (applying ``args``) once, masks it, and — only when
+        something changed — replaces ``record.msg`` with the masked text and
+        clears ``record.args`` so formatters do not re-interpolate. Never raises.
+        """
+        try:
+            rendered = record.getMessage()
+            masked = _mask_patterns(rendered, self._patterns)
+            if masked != rendered:
+                record.msg = masked
+                record.args = ()
+        except Exception:  # nosec B110 — message masking must never raise
+            pass
 
 
 class AttributeFlattenFilter(logging.Filter):

--- a/src/azure_functions_logging/_redaction.py
+++ b/src/azure_functions_logging/_redaction.py
@@ -155,6 +155,6 @@ def mask_patterns(
     for pattern in patterns:
         try:
             result = pattern.sub(lambda m: _mask_replacement(m, mask), result)
-        except Exception:  # nosec B110 — a broken pattern must not stop others
+        except Exception:  # nosec B112 — a broken pattern must not stop others
             continue
     return result

--- a/src/azure_functions_logging/_redaction.py
+++ b/src/azure_functions_logging/_redaction.py
@@ -7,7 +7,8 @@ the same key set and matching rules instead of maintaining separate copies.
 
 from __future__ import annotations
 
-from typing import Any
+import re
+from typing import Any, Iterable
 
 MASK = "***"
 
@@ -87,3 +88,73 @@ def mask_value(
 ) -> Any:
     """Return ``mask`` if ``key`` is sensitive, otherwise the original ``value``."""
     return mask if is_sensitive(key, sensitive_keys) else value
+
+
+# ---------------------------------------------------------------------------
+# Value / pattern-based redaction (opt-in)
+# ---------------------------------------------------------------------------
+#
+# Key-based redaction only masks values whose *key* is sensitive. It cannot see
+# a secret embedded in a free-text message (``"connecting with token=ghp_x"``).
+# ``mask_patterns`` closes that gap by masking substrings that match a secret
+# pattern. It is opt-in (off by default) because pattern scanning has a hot-path
+# cost and can produce false positives; callers enable it explicitly by passing
+# ``patterns=`` to :class:`RedactionFilter`.
+
+# High-confidence secret patterns. Each mask replaces the matched secret with
+# ``MASK``. Patterns that define a ``keep`` named group preserve that captured
+# prefix (e.g. ``token=``) so the log stays readable while the value is masked.
+DEFAULT_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # key=value / key: value secrets — keep the key, mask the value.
+    re.compile(
+        r"(?P<keep>(?i:password|passwd|pwd|token|secret|api[_-]?key|"
+        r"access[_-]?key|client[_-]?secret|refresh[_-]?token|authorization)"
+        r"\s*[=:]\s*)[^\s,;'\"]+"
+    ),
+    # Bearer / auth scheme tokens.
+    re.compile(r"(?P<keep>(?i:bearer)\s+)[A-Za-z0-9._~+/\-]+=*"),
+    # Azure connection-string secrets (AccountKey=, SharedAccessKey=,
+    # SharedAccessSignature=, sig=).
+    re.compile(
+        r"(?P<keep>(?i:AccountKey|SharedAccessKey|SharedAccessSignature|sig)=)"
+        r"[^\s;&,'\"]+"
+    ),
+    # AWS access key id.
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    # GitHub personal/OAuth/app/refresh/server tokens.
+    re.compile(r"gh[posru]_[A-Za-z0-9]{20,}"),
+    # JSON Web Tokens (three base64url segments).
+    re.compile(r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"),
+)
+
+
+def _mask_replacement(match: re.Match[str], mask: str) -> str:
+    """Return the replacement for one match: ``<keep-prefix>MASK`` or ``MASK``."""
+    prefix = match.groupdict().get("keep")
+    return f"{prefix}{mask}" if prefix else mask
+
+
+def mask_patterns(
+    text: str,
+    patterns: Iterable[re.Pattern[str]] = DEFAULT_PATTERNS,
+    mask: str = MASK,
+) -> str:
+    """Mask substrings of ``text`` that match any secret ``patterns``.
+
+    Each matched span is replaced with ``mask``. When a pattern defines a
+    ``keep`` named group, that captured prefix (e.g. ``token=``) is preserved so
+    the surrounding message stays readable and only the secret is masked.
+
+    Never raises: a pattern that errors during substitution is skipped so one
+    broken rule cannot suppress the others (Principle 3 — redaction failures are
+    silent). Non-string / empty input is returned unchanged.
+    """
+    if not text:
+        return text
+    result = text
+    for pattern in patterns:
+        try:
+            result = pattern.sub(lambda m: _mask_replacement(m, mask), result)
+        except Exception:  # nosec B110 — a broken pattern must not stop others
+            continue
+    return result

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 
 import pytest
@@ -1220,3 +1221,181 @@ def test_redaction_does_not_over_redact_benign_dotted_keys(key: str) -> None:
     flt.filter(record)
 
     assert getattr(record, key) == "visible-value"
+
+
+# ---------------------------------------------------------------------------
+# RedactionFilter — value / pattern-based redaction (#435)
+# ---------------------------------------------------------------------------
+
+
+def test_mask_patterns_masks_key_value_secret_preserving_key() -> None:
+    from azure_functions_logging._redaction import mask_patterns
+
+    masked = mask_patterns("connecting with token=ghp_abcdef0123456789ABCDEF ok")
+
+    assert "ghp_abcdef0123456789ABCDEF" not in masked
+    assert "token=***" in masked  # key prefix preserved, value masked
+
+
+def test_mask_patterns_masks_bearer_jwt_aws_and_azure_sig() -> None:
+    from azure_functions_logging._redaction import mask_patterns
+
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N"
+    samples = {
+        "sent Bearer abc.def-123_456 now": "Bearer ***",
+        f"jwt {jwt}": "jwt ***",
+        "key AKIAIOSFODNN7EXAMPLE here": "key *** here",
+        "BlobEndpoint=x;sig=aB3%2FcD4eF5;more": "sig=***",
+    }
+    for text, expected_fragment in samples.items():
+        masked = mask_patterns(text)
+        assert expected_fragment in masked, (text, masked)
+
+
+def test_mask_patterns_leaves_non_matching_text_unchanged() -> None:
+    from azure_functions_logging._redaction import mask_patterns
+
+    text = "processing order o-42 for user u-1 in region koreacentral"
+    assert mask_patterns(text) == text
+
+
+def test_mask_patterns_empty_string_is_returned_unchanged() -> None:
+    from azure_functions_logging._redaction import mask_patterns
+
+    assert mask_patterns("") == ""
+
+
+def test_mask_patterns_skips_pattern_that_raises_and_applies_others() -> None:
+    """Principle 3: a broken pattern must not stop the others or raise."""
+    from azure_functions_logging._redaction import mask_patterns
+
+    class _BoomPattern:
+        def sub(self, *args: object, **kwargs: object) -> str:
+            raise RuntimeError("boom")
+
+    good = re.compile(r"AKIA[0-9A-Z]{16}")
+    masked = mask_patterns(
+        "key AKIAIOSFODNN7EXAMPLE",
+        patterns=[_BoomPattern(), good],  # type: ignore[list-item]
+    )
+    assert "AKIAIOSFODNN7EXAMPLE" not in masked
+    assert "***" in masked
+
+
+def test_redaction_filter_masks_secret_in_message_when_patterns_enabled() -> None:
+    from azure_functions_logging import DEFAULT_REDACTION_PATTERNS
+
+    flt = RedactionFilter(patterns=DEFAULT_REDACTION_PATTERNS)
+    record = _make_record(msg="connecting with token=ghp_abcdef0123456789ABCDEF")
+
+    assert flt.filter(record) is True
+    assert "ghp_abcdef0123456789ABCDEF" not in record.getMessage()
+    assert "token=***" in record.getMessage()
+
+
+def test_redaction_filter_masks_secret_in_message_with_args() -> None:
+    """Message masking renders %-args first, then clears args to avoid re-interp."""
+    from azure_functions_logging import DEFAULT_REDACTION_PATTERNS
+
+    flt = RedactionFilter(patterns=DEFAULT_REDACTION_PATTERNS)
+    record = logging.LogRecord(
+        name="t",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="auth header %s sent",
+        args=("Bearer abc.def-123",),
+        exc_info=None,
+    )
+
+    assert flt.filter(record) is True
+    rendered = record.getMessage()
+    assert "abc.def-123" not in rendered
+    assert "Bearer ***" in rendered
+    assert record.args == ()
+
+
+def test_redaction_filter_masks_secret_in_string_extra() -> None:
+    from azure_functions_logging import DEFAULT_REDACTION_PATTERNS
+
+    flt = RedactionFilter(patterns=DEFAULT_REDACTION_PATTERNS)
+    record = _make_record(msg="safe")
+    setattr(record, "detail", "upstream said password=hunter2!!")
+
+    flt.filter(record)
+
+    assert getattr(record, "detail") == "upstream said password=***"
+
+
+def test_redaction_filter_patterns_leave_non_matching_message_and_extra() -> None:
+    from azure_functions_logging import DEFAULT_REDACTION_PATTERNS
+
+    flt = RedactionFilter(patterns=DEFAULT_REDACTION_PATTERNS)
+    record = _make_record(msg="processing order o-42")
+    setattr(record, "detail", "region koreacentral")
+
+    flt.filter(record)
+
+    assert record.getMessage() == "processing order o-42"
+    assert getattr(record, "detail") == "region koreacentral"
+
+
+def test_redaction_filter_without_patterns_leaves_message_unchanged() -> None:
+    """Backward compatibility: no patterns => message-embedded secrets untouched."""
+    flt = RedactionFilter()
+    record = _make_record(msg="connecting with token=ghp_abcdef0123456789ABCDEF")
+
+    flt.filter(record)
+
+    assert record.getMessage() == "connecting with token=ghp_abcdef0123456789ABCDEF"
+
+
+def test_redaction_filter_accepts_regex_string_patterns() -> None:
+    flt = RedactionFilter(patterns=[r"CUSTOM-[0-9]+"])
+    record = _make_record(msg="id CUSTOM-999 seen")
+
+    flt.filter(record)
+
+    assert record.getMessage() == "id *** seen"
+
+
+def test_redaction_filter_invalid_regex_string_raises_at_construction() -> None:
+    with pytest.raises(re.error):
+        RedactionFilter(patterns=["(unclosed"])
+
+
+def test_redaction_filter_message_masking_never_raises() -> None:
+    """Principle 3: a pattern erroring at runtime must not break filtering."""
+
+    class _BoomPattern:
+        def sub(self, *args: object, **kwargs: object) -> str:
+            raise RuntimeError("boom")
+
+    flt = RedactionFilter()
+    flt._patterns = (_BoomPattern(),)  # type: ignore[assignment]
+    record = _make_record(msg="token=ghp_abcdef0123456789ABCDEF")
+    setattr(record, "detail", "token=ghp_abcdef0123456789ABCDEF")
+
+    assert flt.filter(record) is True  # no exception propagates
+
+
+def test_redaction_filter_patterns_and_keys_compose() -> None:
+    """Key-based redaction and pattern-based redaction both apply."""
+    from azure_functions_logging import DEFAULT_REDACTION_PATTERNS
+
+    flt = RedactionFilter(patterns=DEFAULT_REDACTION_PATTERNS)
+    record = _make_record(msg="login with token=ghp_abcdef0123456789ABCDEF")
+    setattr(record, "password", "s3cr3t")
+
+    flt.filter(record)
+
+    assert getattr(record, "password") == "***"  # key-based
+    assert "ghp_abcdef0123456789ABCDEF" not in record.getMessage()  # pattern-based
+
+
+def test_default_redaction_patterns_is_public_and_nonempty() -> None:
+    import azure_functions_logging as afl
+
+    assert "DEFAULT_REDACTION_PATTERNS" in afl.__all__
+    assert len(afl.DEFAULT_REDACTION_PATTERNS) > 0
+    assert all(isinstance(p, re.Pattern) for p in afl.DEFAULT_REDACTION_PATTERNS)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -83,6 +83,7 @@ def test_public_api_exports() -> None:
         "__version__",
         "AttributeFlattenFilter",
         "ContextTokens",
+        "DEFAULT_REDACTION_PATTERNS",
         "FunctionLogger",
         "JsonFormatter",
         "RedactionFilter",

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -11,6 +11,7 @@ class TestAPISurface:
             "__version__",
             "AttributeFlattenFilter",
             "ContextTokens",
+            "DEFAULT_REDACTION_PATTERNS",
             "FunctionLogger",
             "JsonFormatter",
             "RedactionFilter",


### PR DESCRIPTION
## Context
`RedactionFilter` was **key-based only** — it masked values whose *key* was sensitive but did nothing about secrets embedded inside a free-text log *message* (e.g. `logger.info("connecting with token=ghp_...")`). The README already documented this as a known limitation. This closes that gap with opt-in value/pattern-based redaction.

## Change
- `_redaction.py`: add `DEFAULT_PATTERNS` (bearer tokens, `key=value` secrets, Azure connection-string keys / SAS `sig=`, AWS access-key IDs, GitHub tokens, JWTs) and a `mask_patterns()` helper. Patterns with a `keep` named group preserve a readable prefix (e.g. `token=`) while masking only the value.
- `RedactionFilter` gains an opt-in `patterns=` param (compiled patterns or regex strings) applied to the rendered message and string `extra` values. **Off by default → fully backward compatible.** Runtime substitution failures never raise (Principle 3); an invalid regex string fails fast at construction.
- Export `DEFAULT_REDACTION_PATTERNS` from the public API.
- README ("Noise control & PII redaction" + symptom entry) and `docs/api.md` updated.

## Acceptance Checklist
- [x] Opt-in value/pattern redaction of message + string extras
- [x] Default high-confidence pattern set, off by default
- [x] Key-based behavior unchanged when no patterns supplied (backward compatible)
- [x] Never raises on redaction failure
- [x] `MASK = "***"` remains the single source of truth
- [x] Tests: message-embedded secret masked, extra masked, non-match untouched, malformed pattern degrades safely, backward-compat
- [x] Coverage ≥ 95% (97.02%)
- [x] README + docs updated

## Out of scope
- Full DLP / entropy-based detection; changing the default key set.

Closes #435