### PR TITLE
ci: wire and harden the hatch default-env-pin lint

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Lint documentation links
         run: python tools/lint_doc_links.py
 
+      - name: Hatch/matrix hygiene lint
+        run: python tools/lint_hatch_matrix.py
+
       - name: Ruff style check
         run: |
           ruff check src tests

--- a/tests/test_hatch_matrix_lint.py
+++ b/tests/test_hatch_matrix_lint.py
@@ -116,8 +116,10 @@ jobs:
     assert lint_mod.check_workflow(text, "ci.yml", _PINNED) == []
 
 
-def test_interpreter_guard_makes_it_clean() -> None:
-    # Routes through hatch but proves the interpreter matches the matrix cell.
+def test_interpreter_guard_alone_is_not_enough() -> None:
+    # Routes tests through hatch (hatch run pytest) with only a version_info
+    # guard. The guard asserts the top-level interpreter, but the tests still
+    # run on the pinned hatch env -- so this must be FLAGGED, not cleared.
     text = (
         _MATRIX_BLOCK
         + """
@@ -128,4 +130,5 @@ def test_interpreter_guard_makes_it_clean() -> None:
         # version_info guard tied to matrix.python-version
 """
     )
-    assert lint_mod.check_workflow(text, "ci.yml", _PINNED) == []
+    errors = lint_mod.check_workflow(text, "ci.yml", _PINNED)
+    assert errors and "runs tests through Hatch" in errors[0]

--- a/tools/lint_hatch_matrix.py
+++ b/tools/lint_hatch_matrix.py
@@ -28,11 +28,13 @@ Rule -- a workflow is flagged when ALL of the following hold:
 3. that workflow routes the test run through Hatch (``hatch run`` or a
    ``make`` target known to wrap Hatch: ``install`` / ``check-all`` /
    ``check`` / ``test`` / ``coverage``); and
-4. the workflow does NOT carry an interpreter-match guard -- a step that
-   asserts the runtime ``sys.version_info`` equals ``matrix.python-version``
-   (the belt-and-braces assertion added by the reference fix). A repo that
-   runs tests directly on the matrix interpreter (``python -m pytest``) or
-   proves the interpreter with such a guard is considered safe.
+4. the workflow does NOT run its tests directly on the matrix interpreter --
+   i.e. there is no un-Hatched ``pytest`` / ``python -m pytest`` invocation.
+   A ``sys.version_info`` guard is NOT sufficient on its own: it asserts the
+   top-level interpreter, but a subsequent ``hatch run pytest`` still
+   re-resolves to the pinned env, so the guard cannot prove where the tests
+   actually ran. Only a direct pytest invocation on the matrix interpreter
+   makes the workflow safe.
 
 Stdlib-only on purpose (mirrors ``tools/lint_workflow_pins.py``): the lint must
 not itself depend on a package that can drift. Exit code 0 = clean, 1 = drift.
@@ -61,9 +63,9 @@ _SECTION_RE = re.compile(r"^\s*\[")
 _HATCH_RUN_RE = re.compile(r"\bhatch\s+run\b")
 _HATCH_MAKE_RE = re.compile(r"\bmake\s+(?:" + "|".join(_HATCH_MAKE_TARGETS) + r")\b")
 
-# An interpreter-match guard proves the runtime interpreter equals the matrix cell.
-_GUARD_VERSION_INFO_RE = re.compile(r"\bversion_info\b")
-_GUARD_MATRIX_REF_RE = re.compile(r"matrix\.python-version")
+# A direct pytest invocation (``python -m pytest`` / ``pytest ...``) that is not
+# routed through Hatch proves the tests run on the matrix interpreter itself.
+_DIRECT_PYTEST_RE = re.compile(r"\bpytest\b")
 
 # Inline matrix list: python-version: ["3.10", "3.11"].
 _MATRIX_INLINE_RE = re.compile(r"""python-version:\s*\[(?P<body>[^\]]*)\]""")
@@ -140,11 +142,22 @@ def routes_tests_through_hatch(workflow_text: str) -> bool:
     return bool(_HATCH_RUN_RE.search(workflow_text) or _HATCH_MAKE_RE.search(workflow_text))
 
 
-def has_interpreter_guard(workflow_text: str) -> bool:
-    """True when the workflow asserts the runtime interpreter matches the matrix cell."""
-    return bool(
-        _GUARD_VERSION_INFO_RE.search(workflow_text) and _GUARD_MATRIX_REF_RE.search(workflow_text)
-    )
+def runs_tests_directly_on_matrix(workflow_text: str) -> bool:
+    """True when the workflow invokes pytest directly (not through ``hatch run``).
+
+    The interpreter provisioned by ``actions/setup-python`` is then the one that
+    executes the tests, so the matrix cell is genuinely exercised. A mere
+    ``sys.version_info`` guard is NOT sufficient: it asserts the *top-level*
+    interpreter but a subsequent ``hatch run pytest`` still re-resolves to the
+    pinned Hatch env, so the guard cannot prove where the tests actually ran.
+    """
+    for raw in workflow_text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if _DIRECT_PYTEST_RE.search(line) and "hatch" not in line and "make " not in line:
+            return True
+    return False
 
 
 def check_workflow(workflow_text: str, rel_path: str, pinned: dict[str, str]) -> list[str]:
@@ -156,7 +169,10 @@ def check_workflow(workflow_text: str, rel_path: str, pinned: dict[str, str]) ->
         return []
     if not routes_tests_through_hatch(workflow_text):
         return []
-    if has_interpreter_guard(workflow_text):
+    if runs_tests_directly_on_matrix(workflow_text):
+        # Hatch may still run interpreter-agnostic linters, but the test suite
+        # executes via a direct pytest invocation on the matrix interpreter, so
+        # every cell is genuinely exercised.
         return []
     env_desc = ", ".join(f"{name}={ver}" for name, ver in sorted(pinned.items()))
     return [


### PR DESCRIPTION
## Summary
Part of the fleet default-env-pin lint audit (#576).

- **Wire the lint into CI:** the default-env-pin lint (#433) shipped as `tools/lint_hatch_matrix.py` but was never invoked by any workflow, so it provided zero protection against a hatch-pinned test matrix silently collapsing onto Python 3.10. It now runs in the `quality` job.
- **Harden the lint:** require a direct `pytest` invocation on the matrix interpreter instead of accepting a bare `sys.version_info` guard (which asserts the top-level interpreter but cannot prove a subsequent `hatch run pytest` didn't re-resolve to the pinned env). This repo already runs raw `pytest` on the matrix interpreter, so the lint passes — this closes the audit gap without any runtime change.

## Verification
- `python tools/lint_hatch_matrix.py` — clean
- `pytest tests/test_hatch_matrix_lint.py` — 13 passed
- `ruff check` / `ruff format --check` / `mypy` — clean on changed files

Refs #576, #433