### PR TITLE
ci: run OTel nightly on the upgraded deps, not the pinned hatch env

### DIFF
--- a/.github/workflows/otel-nightly.yml
+++ b/.github/workflows/otel-nightly.yml
@@ -2,7 +2,7 @@ name: OTel Nightly (latest opentelemetry-*)
 
 # Catches breakage from OpenTelemetry upgrades early — in particular the
 # private `opentelemetry.sdk._logs` import used only by the OTel test suite
-# (tests/test_otel_spike.py). Runtime code imports only stable public APIs.
+# (tests/test_otel_contract.py). Runtime code imports only stable public APIs.
 
 on:
   schedule:
@@ -24,10 +24,12 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install package with dev extras
+      - name: Install package with dev + otel extras
+        # Install directly onto the job interpreter (NOT the pinned hatch env) so
+        # the latest-opentelemetry upgrade below actually reaches the test run.
         run: |
-          pip install hatch
-          make install
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,otel]"
 
       - name: Upgrade to the latest opentelemetry-* packages
         run: |
@@ -38,8 +40,8 @@ jobs:
 
       - name: Run OTel-focused test suite
         run: |
-          hatch run pytest -q \
+          python -m pytest -q \
             tests/test_otel.py \
-            tests/test_otel_spike.py \
+            tests/test_otel_contract.py \
             tests/test_otel_filters.py \
             tests/test_host_config_otel.py


### PR DESCRIPTION
## Context

Applying the same fix landed in the sibling repos' nightly workflows (e.g. validation's `worker-nightly.yml`) to this repo's `otel-nightly.yml`, which had the identical Hatch default-env-pin defeat.

## The bug

`otel-nightly.yml` upgrades `opentelemetry-api` / `opentelemetry-sdk` to the latest with `pip install --upgrade`, but then runs the suite via `hatch run pytest`. `hatch run` re-resolves to the Hatch env's own locked opentelemetry versions, so the nightly **never actually exercised the latest packages it just installed** — defeating the entire purpose of the job (catching breakage from OTel upgrades early).

Separately, the suite referenced `tests/test_otel_spike.py`, which was renamed to `tests/test_otel_contract.py` in #438 — so the nightly has also been **erroring on a missing file** since then.

## Changes

- Install the package directly onto the job interpreter via `pip install -e ".[dev,otel]"` (NOT the pinned Hatch env), then run `python -m pytest` so the upgraded OTel packages reach the test run.
- Fix the stale `test_otel_spike.py` → `test_otel_contract.py` reference (and the matching header comment).

## Verification

- `python -m pytest tests/test_otel.py tests/test_otel_contract.py tests/test_otel_filters.py tests/test_host_config_otel.py` → **74 passed**
- `python tools/lint_hatch_matrix.py` → clean (single-version job, not matrix — unaffected either way)